### PR TITLE
Tweaking test runner.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
-    "test": "mocha --compilers ts:ts-node/register",
+    "test": "mocha --compilers ts:ts-node/register --recursive ./test/**/*-test.[tj]s",
     "clean": "rimraf dist"
   },
   "repository": {

--- a/test/bootstrap-test.ts
+++ b/test/bootstrap-test.ts
@@ -1,5 +1,4 @@
 // Typescript test to verify that mocha/chai actually works
-
 import { expect } from "chai";
 
 describe("bootstrap", function () {

--- a/test/util/javascript-test.js
+++ b/test/util/javascript-test.js
@@ -1,0 +1,7 @@
+const expect = require('chai').expect;
+
+describe('Testing from js', function () {
+  it('should run', function () {
+    expect(true).to.be.true;
+  });
+});

--- a/test/util/should-not-run.ts
+++ b/test/util/should-not-run.ts
@@ -1,0 +1,1 @@
+console.log("This shouldn't be run");

--- a/test/util/subdir-test.ts
+++ b/test/util/subdir-test.ts
@@ -1,0 +1,7 @@
+import { expect } from "chai";
+
+describe("test in subdir", function () {
+    it("should pass", function () {
+        expect(true).to.be.true;
+    });
+});


### PR DESCRIPTION
Only run test files that end in "-test.ts" or "-test.js".
Recurse down subdirectories.
Added a couple example tests to prove it works.
