### PR TITLE
Fix crash in test runs.

### DIFF
--- a/test/util/commandline/command-loader-test.ts
+++ b/test/util/commandline/command-loader-test.ts
@@ -3,7 +3,10 @@ import * as path from "path";
 import { expect } from "chai";
 import * as sinon from "sinon";
 
-import { Command } from "../../../src/util/commandline";
+// Force require of Commandline module to avoid weird circular-reference crash that
+// only occurs when running from tests. Very strange.
+require("../../../src/util/commandline");
+
 import { CommandLoader, loader } from "../../../src/util/commandline/command-loader";
 import { CommandFinder, finder } from "../../../src/util/commandline/command-finder";
 


### PR DESCRIPTION
Apparently there's a weird circular ref bug in the test logic when using
the command loader which only appears in the tests. By forcing a require
of the commandline module before running the tests the circular refs are
resolved. Very strange, but don't have time to debug further right now.
