### PR TITLE
Test Cloud TC-360: CLI: status reporting for 'run' commands

### DIFF
--- a/src/commands/test/lib/state-checker.ts
+++ b/src/commands/test/lib/state-checker.ts
@@ -1,0 +1,59 @@
+import { MobileCenterClient, models, clientCall } from "../../../util/apis";
+import { out } from "../../../util/interaction";
+import * as os from "os";
+
+export class StateChecker {
+  private readonly client: MobileCenterClient;
+  private readonly testRunId: string;
+  private readonly ownerName: string;
+  private readonly appName: string;
+
+  constructor(client: MobileCenterClient, testRunId: string, ownerName: string, appName: string) {
+    this.client = client;
+    this.testRunId = testRunId;
+    this.ownerName = ownerName;
+    this.appName = appName;
+  }
+  
+  public async checkUntilCompleted(): Promise<number> {
+    let exitCode = 0;
+
+    while (true) {
+      let state = await out.progress("Checking status...", this.getTestRunState(this.client, this.testRunId));
+      out.text(`Current test status: ${state.message.join(os.EOL)}`);
+
+      if (typeof state.exitCode === "number") {
+        exitCode = state.exitCode;
+        break;
+      }
+
+      await out.progress(`Waiting ${state.waitTime} seconds...`, this.delay(1000 * state.waitTime));
+    }
+
+    return exitCode;
+  }
+
+  public async checkOnce(): Promise<number> {
+    let state = await out.progress("Checking status...", this.getTestRunState(this.client, this.testRunId));
+    out.text(`Current test status: ${state.message.join(os.EOL)}`);
+
+    return state.exitCode;
+  }
+
+  private getTestRunState(client: MobileCenterClient, testRunId: string): Promise<models.TestRunState> {
+    return clientCall(cb => {
+      client.test.getTestRunState(
+        testRunId,
+        this.ownerName,
+        this.appName,
+        cb
+      );
+    });
+  } 
+
+  private async delay(milliseconds: number): Promise<void> {
+    return new Promise<void>(resolve => {
+      setTimeout(resolve, milliseconds);
+    });
+  }
+}


### PR DESCRIPTION
With this change, the `test run` commands will poll for status in the same way they used to with old uploaders (unless `--async` option is used).

Sample output:
```
.\mobile-center test run uitest --app "skovsboll-ms/ubehagelig-wrestling" --devices bcd8cdfe ...

Preparing tests... done.
Validating arguments... done.
Creating new test run... done.
Validating application file... done.
Uploading application file... done.
Uploading test files... done.
Starting test run... done.
Test run id: "74b98397-7553-4ebe-ba96-2bbd65a20b0b"
Accepted devices:
  - LG Nexus 5 (5.0)
Current test status: Validating
Current test status: Validating
Current test status: Validation completed. Waiting for devices
...
Current test status: Validation completed. Waiting for devices
Current test status: Running on 1 device (0 / 1 completed, 0 pending)
...
Current test status: Running on 1 device (0 / 1 completed, 0 pending)
Current test status: Tests completed. Processing data.
Current test status: Tests completed. Processing data.
Current test status: Done!
Total scenarios: 1
1 passed
0 failed
Total steps: 1
```