### PR TITLE
Test Cloud: implementing detection of test-cloud.exe

### DIFF
--- a/src/commands/test/lib/uitest-preparer.ts
+++ b/src/commands/test/lib/uitest-preparer.ts
@@ -1,8 +1,12 @@
 import { TestCloudError } from "./test-cloud-error";
+import * as _ from "lodash";
+import * as glob from "glob";
+import * as os from "os";
 import * as path from "path";
 import * as process from "../../../util/misc/process-helper";
 
 const debug = require("debug")("mobile-center:commands:test:lib:uitest-preparer");
+const minimumVersion = [2, 0, 1];
 
 export class UITestPreparer {
   private readonly appPath: string;
@@ -16,6 +20,7 @@ export class UITestPreparer {
   public signInfo: string;
   public include: string[];
   public testParameters: string[];
+  public uiTestToolsDir: string;  
 
   constructor(artifactsDir: string, assemblyDir: string, appPath: string) {
     if (!artifactsDir) {
@@ -36,7 +41,7 @@ export class UITestPreparer {
   public async prepare(): Promise<string> {
     this.validateArguments();
 
-    let command = this.getPrepareCommand();
+    let command = await this.getPrepareCommand();
     debug(`Executing command ${command}`);
     let exitCode = await process.execAndWait(command);
 
@@ -55,8 +60,14 @@ export class UITestPreparer {
     }
   }
 
-  private getPrepareCommand(): string {
-    let command = `test-cloud prepare "${this.appPath}"`;
+  private async getPrepareCommand(): Promise<string> {
+    let command = "";
+    if (os.platform() !== "win32") {
+      command += `mono `;
+    }
+
+    let testCloudBinary = await this.getTestCloudExecutablePath();
+    command += `${testCloudBinary} prepare "${this.appPath}"`;
 
     if (this.storeFile) {
       command += ` "${this.storeFile}" "${this.storePassword}" "${this.keyAlias}" "${this.keyPassword}"`;
@@ -77,5 +88,81 @@ export class UITestPreparer {
     }
 
     return command;
+  }
+
+  private async getTestCloudExecutablePath(): Promise<string> {
+    let toolsDir = this.uiTestToolsDir || await this.findXamarinUITestNugetDir(this.assemblyDir);
+    return path.join(toolsDir, "test-cloud.exe");
+  }
+
+  private async findXamarinUITestNugetDir(root: string): Promise<string> {
+    let possibleNugetDirPattern = path.join(root, "packages", "Xamarin.UITest.*", "tools", "test-cloud.exe");
+    let files = (await this.globAsync(possibleNugetDirPattern)).sort();
+    
+    if (files.length === 0) {
+       let parentDir = path.dirname(root);
+       
+       if (parentDir === root) {
+         throw new Error(`Cannot find test-cloud.exe, which is required to prepare UI tests.${os.EOL}` + 
+          `We have searched for directory "packages${path.sep}Xamarin.UITest.*${path.sep}tools" inside ` + 
+          `"${this.assemblyDir}" and all of its parent directories.${os.EOL}` + 
+          `Please use option "--uitest-tools-dir" to manually specify location of this tool.${os.EOL}` + 
+          `Minimum required version is "${this.getMinimumVersionString()}".`);
+       }
+       else {
+         return await this.findXamarinUITestNugetDir(parentDir);
+       }
+    }
+    else {
+      let latestTestCloudPath = files[files.length - 1];
+      let match = latestTestCloudPath.match(/Xamarin\.UITest\.(\d+)\.(\d+)\.(\d+)/);
+
+      if (!match) {
+        throw new Error(`Found test-cloud.exe at "${path.dirname(latestTestCloudPath)}", but cannot recognize its version.${os.EOL}` + 
+                        `Please use option "--uitest-tools-dir" to manually specify location of this tool.${os.EOL}` + 
+                        `Minimum required version is "${this.getMinimumVersionString()}".`);
+      }
+
+      let [, major, minor, build] = match; 
+      if (!this.hasMinimumTestCloudVersion(parseInt(major), parseInt(minor), parseInt(build))) {
+        throw new Error(`The latest version of test-cloud.exe, found at "${path.dirname(latestTestCloudPath)}", ` + 
+                        `is too old.${os.EOL}` +
+                        `Please upgrade the NuGet package to version ${this.getMinimumVersionString()} or higher.`);  
+      }
+      else {
+        return path.dirname(latestTestCloudPath);
+      }
+    }
+  }
+
+  private async globAsync(pattern: string): Promise<string[]> {
+    return new Promise<string[]>((resolve, reject) => {
+      glob(pattern, (err, matches) => {
+        if (err) {
+          reject(err);
+        }
+        else {
+          resolve(matches);
+        }
+      });
+    });
+  }
+
+  private getMinimumVersionString(): string {
+    return `${minimumVersion[0]}.${minimumVersion[1]}.${minimumVersion[2]}`;
+  }
+
+  private hasMinimumTestCloudVersion(major: number, minor: number, build: number): boolean {
+    let currentVersion = [major, minor, build];
+
+    let minLength = Math.min(currentVersion.length, minimumVersion.length);
+
+    for (let i = 0; i < minLength; i++) {
+      if (currentVersion[i] < minimumVersion[i]) {
+        return false;
+      }
+    }
+
+    return true;
   }
 }

--- a/src/commands/test/prepare/uitest.ts
+++ b/src/commands/test/prepare/uitest.ts
@@ -53,6 +53,11 @@ export default class PrepareUITestCommand extends Command {
   @hasArg
   signInfo: string;
 
+  @help("Path to Xamarin UITest tools directory that contains test-cloud.exe")
+  @longName("uitest-tools-dir")
+  @hasArg
+  uiTestToolsDir: string;
+
   @help("Additional files / directories that should be included in the test run. The value should be in format 'sourceDir=targetDir'")
   @longName("include")
   @hasArg
@@ -92,6 +97,7 @@ export default class PrepareUITestCommand extends Command {
       preparer.keyPassword = this.keyPassword;
       preparer.include = this.include;
       preparer.testParameters = this.testParameters;
+      preparer.uiTestToolsDir = this.uiTestToolsDir;
 
       let manifestPath = await preparer.prepare();
       out.text(`UI Tests are ready to run. Manifest file was written to ${manifestPath}.`);

--- a/src/commands/test/run/uitest.ts
+++ b/src/commands/test/run/uitest.ts
@@ -43,6 +43,11 @@ export default class RunUITestsCommand extends RunTestsCommand {
   @hasArg
   signInfo: string;
 
+  @help("Path to Xamarin UITest tools directory that contains test-cloud.exe")
+  @longName("uitest-tools-dir")
+  @hasArg
+  uiTestToolsDir: string;
+
   constructor(args: CommandArgs) {
     super(args);
   }
@@ -56,6 +61,7 @@ export default class RunUITestsCommand extends RunTestsCommand {
     preparer.keyPassword = this.keyPassword;
     preparer.include = this.include;
     preparer.testParameters = this.testParameters;
+    preparer.uiTestToolsDir = this.uiTestToolsDir;
 
     return await preparer.prepare();
   }


### PR DESCRIPTION
So far we have assumed that test-cloud.exe, required by UI Tests, is on the PATH. This is not true for most users.

This PR tries to find NuGet directory (packages) in all ancestors of the assembly-dir, and check for Xamarin.UITest* nugget inside. Also, if it cannot find the tool, it allows user to manually set the correct location using --uitest-tools-dir.
