### PR TITLE
Feature/test-cloud espresso support

### DIFF
--- a/mobile-center
+++ b/mobile-center
@@ -1,0 +1,2 @@
+#!/bin/bash
+node dist/index.js "$@"

--- a/mobile-center
+++ b/mobile-center
@@ -1,2 +1,0 @@
-#!/bin/bash
-node dist/index.js "$@"

--- a/src/commands/test/lib/espresso-preparer.ts
+++ b/src/commands/test/lib/espresso-preparer.ts
@@ -26,7 +26,13 @@ export class EspressoPreparer {
   }
 
   private validateEitherProjectBuildDirOrTestApkPath() {
-    if ((this.projectDir && this.buildDir) || !(this.projectDir || this.buildDir)) {
+    if (this.projectDir && (this.buildDir || this.testApkPath)) {
+      throw new Error("You must not specify build dir if project dir or test apk path is specified.");
+    }
+    if (this.buildDir && this.testApkPath) {
+      throw new Error("You must not specify both build dir and test apk path.");
+    }
+    if (!(this.projectDir || this.buildDir || this.testApkPath)) {
       throw new Error("Either projectDir, buildDir or testApkPath must be specified");
     }
   }
@@ -42,7 +48,7 @@ export class EspressoPreparer {
                     this.testApkPath,
                     true,
                     `File not found for test apk path: "${this.testApkPath}"`);
-      await pfs.copyFile(this.testApkPath, this.artifactsDir);
+      await pfs.copyFile(this.testApkPath, path.join(this.artifactsDir, path.basename(this.testApkPath)));
     }
     else {
       await this.validateBuildDir();

--- a/src/commands/test/lib/espresso-preparer.ts
+++ b/src/commands/test/lib/espresso-preparer.ts
@@ -1,0 +1,149 @@
+import { IFileDescriptionJson } from "./test-manifest-reader";
+import { out } from "../../../util/interaction";
+import * as _ from "lodash";
+import * as fs from "fs";
+import * as path from "path";
+import * as glob from "glob";
+import * as pfs from "../../../util/misc/promisfied-fs";
+
+export class EspressoPreparer {
+  private readonly artifactsDir: string;
+  private buildDir: string;
+  private projectDir: string;
+  public include: IFileDescriptionJson[];
+  public testParameters: { [key:string]: any };
+
+  constructor(artifactsDir: string, projectDir?: string, buildDir?: string) {
+    if (!artifactsDir) {
+      throw new Error("Argument artifactsDir is required");
+    }
+
+    this.projectDir = projectDir;
+    this.buildDir = buildDir;
+    this.artifactsDir = artifactsDir;
+
+    this.validateEitherProjectOrBuildDir();
+  }
+
+  private validateEitherProjectOrBuildDir() {
+    if ((this.projectDir && this.buildDir) || !(this.projectDir || this.buildDir)) {
+      throw new Error("Either projectDir or buildDir must be specified");
+    }
+  }
+
+  public async prepare(): Promise<string> {
+    if (this.projectDir) {
+      await this.validateProjectDir();
+      this.buildDir = await this.generateBuildDirFromProject();
+    }
+
+    this.validateBuildDir();
+
+    await pfs.copyDir(this.buildDir, this.artifactsDir);
+
+    let manifestPath = path.join(this.artifactsDir, "test-manifest.json");
+    let manifest = await this.createEspressoManifest();
+    let manifestJson = JSON.stringify(manifest, null, 1);
+    await pfs.writeFile(manifestPath, manifestJson);
+
+    return manifestPath;
+  }
+
+  private async validateProjectDir() {
+    await this.validatePathExists(
+      this.projectDir, 
+      false, 
+      `Project directory ${this.projectDir} doesn't exist`);
+  }
+
+  private async generateBuildDirFromProject(): Promise<string> {
+    throw new Error("Not implemented");
+  }
+
+  private async validateBuildDir() {
+    await this.validateBuildDirExists();    
+    await this.validateTestApkExists();
+  }
+
+  private async globAsync(pattern: string): Promise<string[]> {
+    return new Promise<string[]>((resolve, reject) => {
+      glob(pattern, (err, matches) => {
+        if (err) {
+          reject(err);
+        }
+        else {
+          resolve(matches);
+        }
+      });
+    });
+  }
+
+  private async validateBuildDirExists() {
+    await this.validatePathExists(
+      this.buildDir,
+      false,
+      `Espresso build directory "${this.buildDir}" doesn't exist`);
+  }
+
+  private async validateTestApkExists(): Promise<void> {
+    await this.testApkPath();      
+  }
+
+  private async testApkPath(): Promise<string> {
+    let apkPattern = path.join(this.buildDir,"*androidTest.apk");
+    let files = await this.globAsync(apkPattern);
+    
+    if (files.length === 0) {
+       throw new Error(`An apk with name matching "*androidTest.apk" was not found inside directory inside build directory "${this.buildDir}"`);
+    }
+    else if (files.length >= 2) {
+       throw new Error(`Multiple apks with name matching "*androidTest.apk" was found inside directory inside build directory "${this.buildDir}". A unique match is required.`);
+    }
+    else {
+      let apkPath = files[files.length - 1];
+      return apkPath;
+    }
+  }
+
+  private async validatePathExists(path: string, isFile: boolean, errorMessage: string): Promise<void> {
+    let stats: fs.Stats = null;
+    
+    try {
+      stats = await pfs.stat(path);
+    }
+    catch (err) {
+      throw new Error(errorMessage);
+    }
+
+    if (isFile !== stats.isFile()) {
+      throw new Error(errorMessage);
+    }
+  }
+
+  private async createEspressoManifest(): Promise<any> {
+    let apkFullPath = await this.testApkPath();
+    let apkArtifactsPath = path.basename(apkFullPath); 
+    let result = {
+      "schemaVersion": "1.0.0",
+      "files": [apkArtifactsPath],
+      "testFramework": {
+        "name": "espresso",
+        "data": { }
+      }
+    };
+
+    if (this.include) {
+      for (let i = 0; i < this.include.length; i++) {
+        
+        let includedFile = this.include[i];
+        let targetPath = path.join(this.artifactsDir, includedFile.targetPath);
+        await pfs.copy(includedFile.sourcePath, targetPath);
+        result.files.push(includedFile.targetPath);
+      }
+    }
+
+    _.merge(result.testFramework.data, this.testParameters || {}); 
+
+    return result;
+  }
+}

--- a/src/commands/test/prepare/espresso.ts
+++ b/src/commands/test/prepare/espresso.ts
@@ -1,0 +1,63 @@
+import { Command, CommandArgs, CommandResult, 
+         help, success, name, shortName, longName, required, hasArg,
+         position, failure, notLoggedIn, ErrorCodes } from "../../../util/commandLine";
+import { EspressoPreparer } from "../lib/espresso-preparer";
+import { out } from "../../../util/interaction";
+import { parseTestParameters } from "../lib/parameters-parser";
+import { parseIncludedFiles } from "../lib/included-files-parser";
+
+@help("Prepares Espresso artifacts for test run")
+export default class PrepareEspressoCommand extends Command {
+  @help("Path to output directory where all test files will be copied")
+  @longName("artifacts-dir")
+  @hasArg
+  artifactsDir: string;
+
+  @help("Path to Espresso output directory (usually <project>/build/outputs/apk)")
+  @longName("build-dir")
+  @hasArg
+  buildDir: string;
+
+  @help("Path to Espresso test project that should be built")
+  @longName("project-dir")
+  @hasArg
+  projectDir: string;
+
+  @help("Additional files / directories that should be included in the test run. The value should be in format 'sourceDir=targetDir'")
+  @longName("include")
+  @hasArg
+  include: string[];
+
+  @help("Additional test parameters that should be included in the test run. The value should be in format key=value")
+  @longName("test-parameter")
+  @shortName("p")
+  @hasArg
+  testParameters: string[];
+
+  constructor(args: CommandArgs) {
+    super(args);
+
+    if (typeof this.testParameters === "string") {
+      this.testParameters = [ this.testParameters ];
+    }
+
+    if (typeof this.include === "string") {
+      this.include = [ this.include ];
+    }
+  }
+
+  public async runNoClient(): Promise<CommandResult> {
+    try {
+      let preparer = new EspressoPreparer(this.artifactsDir, this.projectDir, this.buildDir);
+      preparer.include = parseIncludedFiles(this.include || []);
+      preparer.testParameters = parseTestParameters(this.testParameters || []);
+
+      let manifestPath = await preparer.prepare();
+      out.text(`Espresso tests are ready to run. Manifest file was written to ${manifestPath}.`);
+      return success();
+    } 
+    catch (err) {
+      return failure(ErrorCodes.Exception, err.message);
+    }
+  }
+}

--- a/src/commands/test/run/espresso.ts
+++ b/src/commands/test/run/espresso.ts
@@ -34,6 +34,9 @@ export default class RunEspressoTestsCommand extends RunTestsCommand {
   }
 
   protected async prepareArtifactsDir(artifactsDir: string): Promise<string> {
+    if (!this.appPath) {
+      throw new Error("Argument --app-path is required");
+    }
     let preparer = new EspressoPreparer(artifactsDir, this.projectDir, this.buildDir, this.testApkPath);
     preparer.include = parseIncludedFiles(this.include || []);
     preparer.testParameters = parseTestParameters(this.testParameters || []);

--- a/src/commands/test/run/espresso.ts
+++ b/src/commands/test/run/espresso.ts
@@ -1,0 +1,30 @@
+import { CommandArgs, help, name, longName, hasArg, ErrorCodes } from "../../../util/commandLine";
+import { RunTestsCommand } from "../lib/run-tests-command";
+import { EspressoPreparer } from "../lib/espresso-preparer";
+import { parseTestParameters } from "../lib/parameters-parser";
+import { parseIncludedFiles } from "../lib/included-files-parser";
+
+@help("Prepares and runs Espresso tests")
+export default class RunEspressoTestsCommand extends RunTestsCommand {
+  @help("Path to Espresso build directory (usually <project>/build/outputs/apk)")
+  @longName("build-dir")
+  @hasArg
+  buildDir: string;
+
+  @help("Path to Espresso test project that should be built")
+  @longName("project-dir")
+  @hasArg
+  projectDir: string;
+
+  constructor(args: CommandArgs) {
+    super(args);
+  }
+
+  protected async prepareArtifactsDir(artifactsDir: string): Promise<string> {
+    let preparer = new EspressoPreparer(artifactsDir, this.projectDir, this.buildDir);
+    preparer.include = parseIncludedFiles(this.include || []);
+    preparer.testParameters = parseTestParameters(this.testParameters || []);
+
+    return await preparer.prepare();
+  }
+}

--- a/src/commands/test/run/espresso.ts
+++ b/src/commands/test/run/espresso.ts
@@ -1,4 +1,4 @@
-import { CommandArgs, help, name, longName, hasArg, ErrorCodes } from "../../../util/commandLine";
+import { CommandArgs, help, name, longName, hasArg, ErrorCodes, required } from "../../../util/commandLine";
 import { RunTestsCommand } from "../lib/run-tests-command";
 import { EspressoPreparer } from "../lib/espresso-preparer";
 import { parseTestParameters } from "../lib/parameters-parser";
@@ -6,6 +6,13 @@ import { parseIncludedFiles } from "../lib/included-files-parser";
 
 @help("Prepares and runs Espresso tests")
 export default class RunEspressoTestsCommand extends RunTestsCommand {
+
+  @help("Path to an application file")
+  @longName("app-path")
+  @required
+  @hasArg
+  appPath: string;
+
   @help("Path to Espresso build directory (usually <project>/build/outputs/apk)")
   @longName("build-dir")
   @hasArg
@@ -16,12 +23,18 @@ export default class RunEspressoTestsCommand extends RunTestsCommand {
   @hasArg
   projectDir: string;
 
+
+  @help("Path to Espresso tests .apk file (default uses build-dir to detect this file)")
+  @longName("test-apk-path")
+  @hasArg
+  testApkPath: string;
+
   constructor(args: CommandArgs) {
     super(args);
   }
 
   protected async prepareArtifactsDir(artifactsDir: string): Promise<string> {
-    let preparer = new EspressoPreparer(artifactsDir, this.projectDir, this.buildDir);
+    let preparer = new EspressoPreparer(artifactsDir, this.projectDir, this.buildDir, this.testApkPath);
     preparer.include = parseIncludedFiles(this.include || []);
     preparer.testParameters = parseTestParameters(this.testParameters || []);
 


### PR DESCRIPTION
A first take for Espresso support for Test beacon

@kmiecikt please review this draft proposal -- I'm aware of quite a bit of duplication, but I wanted to have you own how you want code to be shared

Note: also created a `./mobile-center` helper for OS X which I found useful as a beginner

Note: requires https://github.com/xamarin/test-cloud-frontend/commit/44015bd66a8838c24dd11a2c8a1c9a5d2163dd58 to test this end to end (this should be deployed tomorrow at least to staging)

