### PR TITLE
Test cloud: making argument names consistent for all supported frameworks:

### DIFF
--- a/src/commands/test/lib/appium-preparer.ts
+++ b/src/commands/test/lib/appium-preparer.ts
@@ -8,34 +8,22 @@ import * as pfs from "../../../util/misc/promisfied-fs";
 export class AppiumPreparer {
   private readonly artifactsDir: string;
   private buildDir: string;
-  private projectDir: string;
   public include: IFileDescriptionJson[];
   public testParameters: { [key:string]: any };
 
-  constructor(artifactsDir: string, projectDir?: string, buildDir?: string) {
+  constructor(artifactsDir: string, buildDir: string) {
     if (!artifactsDir) {
       throw new Error("Argument artifactsDir is required");
     }
+    if (!buildDir) {
+      throw new Error("Argument buildDir is required");
+    }
 
     this.artifactsDir = artifactsDir;
-    this.projectDir = projectDir;
     this.buildDir = buildDir;
-
-    this.validateEitherProjectOrBuildDir();
-  }
-
-  private validateEitherProjectOrBuildDir() {
-    if ((this.projectDir && this.buildDir) || !(this.projectDir || this.buildDir)) {
-      throw new Error("Either projectDir or buildDir must be specified");
-    }
   }
 
   public async prepare(): Promise<string> {
-    if (this.projectDir) {
-      await this.validateProjectDir();
-      this.buildDir = await this.generateBuildDirFromProject();
-    }
-
     await this.validateBuildDir();
     await pfs.cpDir(this.buildDir, this.artifactsDir);
 
@@ -45,17 +33,6 @@ export class AppiumPreparer {
     await pfs.writeFile(manifestPath, manifestJson);
 
     return manifestPath;
-  }
-
-  private async validateProjectDir() {
-    await this.validatePathExists(
-      this.projectDir, 
-      false, 
-      `Project directory ${this.projectDir} doesn't exist`);
-  }
-
-  private async generateBuildDirFromProject(): Promise<string> {
-    throw new Error("Not implemented");
   }
 
   private async validateBuildDir() {

--- a/src/commands/test/lib/calabash-preparer.ts
+++ b/src/commands/test/lib/calabash-preparer.ts
@@ -6,7 +6,7 @@ const debug = require("debug")("mobile-center-cli:commands:test:lib:calabash-pre
 
 export class CalabashPreparer {
   private readonly appPath: string;
-  private readonly workspace: string;
+  private readonly projectDir: string;
   private readonly artifactsDir: string;
 
   public signInfo: string;
@@ -16,19 +16,19 @@ export class CalabashPreparer {
   public include: string[];
   public testParameters: string[];
 
-  constructor(artifactsDir: string, workspace: string, appPath: string) {
+  constructor(artifactsDir: string, projectDir: string, appPath: string) {
     if (!artifactsDir) {
       throw new Error("Argument artifactsDir is required");
     }
-    if (!workspace) {
-      throw new Error("Argument workspace is required");
+    if (!projectDir) {
+      throw new Error("Argument projectDir is required");
     }
     if (!appPath) {
       throw new Error("Argument appPath is required");
     }
 
     this.artifactsDir = artifactsDir;
-    this.workspace = workspace;
+    this.projectDir = projectDir;
     this.appPath = appPath;
   }
 
@@ -46,7 +46,7 @@ export class CalabashPreparer {
 
   private getPrepareCommand(): string {
     let command = `test-cloud prepare ${this.appPath} --artifacts-dir ${this.artifactsDir}`;
-    command += ` --workspace "${this.workspace}"`;
+    command += ` --workspace "${this.projectDir}"`;
 
     if (this.config) {
       command += ` --config "${this.config}"`;

--- a/src/commands/test/lib/path-resolver.ts
+++ b/src/commands/test/lib/path-resolver.ts
@@ -1,4 +1,4 @@
-import * as glob from "glob";
+import { glob } from "../../../util/misc/promisfied-glob";
 import * as path from "path";
 import * as fs from "fs";
 import * as _ from "lodash";
@@ -34,7 +34,7 @@ export class PathResolver {
       }
     }
     
-    let matches = await this.globAsync(workspacePattern);
+    let matches = await glob(workspacePattern);
     let result: string[] = [];
 
     for (let i = 0; i < matches.length; i++) {
@@ -61,18 +61,5 @@ export class PathResolver {
     }
 
     return relativePath;
-  }
-
-  private globAsync(pattern: string): Promise<string[]> {
-    return new Promise<string[]>((resolve, reject) => {
-      glob(pattern, (error, matches) => {
-        if (error) {
-          reject(error);
-        }
-        else {
-          resolve(matches);
-        }
-      })
-    });
   }
 };

--- a/src/commands/test/lib/test-manifest.ts
+++ b/src/commands/test/lib/test-manifest.ts
@@ -1,5 +1,6 @@
 import * as fs from "fs";
 import * as crypto from "crypto";
+import * as glob from "glob";
 
 export type TestRunFileType = "app-file" | "dsym-file" | "test-file"; 
 

--- a/src/commands/test/lib/uitest-preparer.ts
+++ b/src/commands/test/lib/uitest-preparer.ts
@@ -1,6 +1,6 @@
 import { TestCloudError } from "./test-cloud-error";
+import { glob } from "../../../util/misc/promisfied-glob";
 import * as _ from "lodash";
-import * as glob from "glob";
 import * as os from "os";
 import * as path from "path";
 import * as process from "../../../util/misc/process-helper";
@@ -97,7 +97,7 @@ export class UITestPreparer {
 
   private async findXamarinUITestNugetDir(root: string): Promise<string> {
     let possibleNugetDirPattern = path.join(root, "packages", "Xamarin.UITest.*", "tools", "test-cloud.exe");
-    let files = (await this.globAsync(possibleNugetDirPattern)).sort();
+    let files = (await glob(possibleNugetDirPattern)).sort();
 
     if (files.length === 0) {
        let parentDir = path.dirname(root);
@@ -133,19 +133,6 @@ export class UITestPreparer {
         return path.dirname(latestTestCloudPath);
       }
     }
-  }
-
-  private async globAsync(pattern: string): Promise<string[]> {
-    return new Promise<string[]>((resolve, reject) => {
-      glob(pattern, (err, matches) => {
-        if (err) {
-          reject(err);
-        }
-        else {
-          resolve(matches);
-        }
-      });
-    });
   }
 
   private getMinimumVersionString(): string {

--- a/src/commands/test/lib/uitest-preparer.ts
+++ b/src/commands/test/lib/uitest-preparer.ts
@@ -10,7 +10,7 @@ const minimumVersion = [2, 0, 1];
 
 export class UITestPreparer {
   private readonly appPath: string;
-  private readonly assemblyDir: string;
+  private readonly buildDir: string;
   private readonly artifactsDir: string;
 
   public storeFile: string;
@@ -22,19 +22,19 @@ export class UITestPreparer {
   public testParameters: string[];
   public uiTestToolsDir: string;
 
-  constructor(artifactsDir: string, assemblyDir: string, appPath: string) {
+  constructor(artifactsDir: string, buildDir: string, appPath: string) {
     if (!artifactsDir) {
       throw new Error("Argument artifactsDir is required");
     }
-    if (!assemblyDir) {
-      throw new Error("Argument assemblyDir is required");
+    if (!buildDir) {
+      throw new Error("Argument buildDir is required");
     }
     if (!appPath) {
       throw new Error("Argument appPath is required");
     }
 
     this.appPath = appPath;
-    this.assemblyDir = assemblyDir;
+    this.buildDir = buildDir;
     this.artifactsDir = artifactsDir;
   }
 
@@ -73,7 +73,7 @@ export class UITestPreparer {
       command += ` "${this.storeFile}" "${this.storePassword}" "${this.keyAlias}" "${this.keyPassword}"`;
     }
 
-    command += ` --assembly-dir "${this.assemblyDir}" --artifacts-dir "${this.artifactsDir}"`;
+    command += ` --assembly-dir "${this.buildDir}" --artifacts-dir "${this.artifactsDir}"`;
 
     for (let i = 0; i < this.testParameters.length; i++) {
       command += ` --test-parameter "${this.testParameters[i]}"`;
@@ -91,7 +91,7 @@ export class UITestPreparer {
   }
 
   private async getTestCloudExecutablePath(): Promise<string> {
-    let toolsDir = this.uiTestToolsDir || await this.findXamarinUITestNugetDir(this.assemblyDir);
+    let toolsDir = this.uiTestToolsDir || await this.findXamarinUITestNugetDir(this.buildDir);
     return path.join(toolsDir, "test-cloud.exe");
   }
 
@@ -105,7 +105,7 @@ export class UITestPreparer {
        if (parentDir === root) {
          throw new Error(`Cannot find test-cloud.exe, which is required to prepare UI tests.${os.EOL}` +
           `We have searched for directory "packages${path.sep}Xamarin.UITest.*${path.sep}tools" inside ` +
-          `"${this.assemblyDir}" and all of its parent directories.${os.EOL}` +
+          `"${this.buildDir}" and all of its parent directories.${os.EOL}` +
           `Please use option "--uitest-tools-dir" to manually specify location of this tool.${os.EOL}` +
           `Minimum required version is "${this.getMinimumVersionString()}".`);
        }

--- a/src/commands/test/prepare/appium.ts
+++ b/src/commands/test/prepare/appium.ts
@@ -18,11 +18,6 @@ export default class PrepareAppiumCommand extends Command {
   @hasArg
   buildDir: string;
 
-  @help("Path to Appium test project that should be built")
-  @longName("project-dir")
-  @hasArg
-  projectDir: string;
-
   @help("Additional files / directories that should be included in the test run. The value should be in format 'sourceDir=targetDir'")
   @longName("include")
   @hasArg
@@ -48,7 +43,7 @@ export default class PrepareAppiumCommand extends Command {
 
   public async runNoClient(): Promise<CommandResult> {
     try {
-      let preparer = new AppiumPreparer(this.artifactsDir, this.projectDir, this.buildDir);
+      let preparer = new AppiumPreparer(this.artifactsDir, this.buildDir);
       preparer.include = parseIncludedFiles(this.include || []);
       preparer.testParameters = parseTestParameters(this.testParameters || []);
 

--- a/src/commands/test/prepare/calabash.ts
+++ b/src/commands/test/prepare/calabash.ts
@@ -17,10 +17,10 @@ export default class PrepareCalabashCommand extends Command {
   appPath: string;
 
   @help("Path to workspace")
-  @longName("workspace")
+  @longName("project-dir")
   @required
   @hasArg
-  workspace: string;
+  projectDir: string;
 
   @help("Path to output directory with all test artifacts")
   @longName("artifacts-dir")
@@ -78,7 +78,7 @@ export default class PrepareCalabashCommand extends Command {
 
   public async runNoClient(): Promise<CommandResult> {
     try {
-      let preparer = new CalabashPreparer(this.artifactsDir, this.workspace, this.appPath);
+      let preparer = new CalabashPreparer(this.artifactsDir, this.projectDir, this.appPath);
 
       preparer.signInfo = this.signInfo;
       preparer.config = this.config;

--- a/src/commands/test/prepare/uitest.ts
+++ b/src/commands/test/prepare/uitest.ts
@@ -17,10 +17,10 @@ export default class PrepareUITestCommand extends Command {
   appPath: string;
 
   @help("Path to directory with test assemblies")
-  @longName("assembly-dir")
+  @longName("build-dir")
   @required
   @hasArg
-  assemblyDir: string;
+  buildDir: string;
 
   @help("Path to output directory with all test artifacts")
   @longName("artifacts-dir")
@@ -89,7 +89,7 @@ export default class PrepareUITestCommand extends Command {
 
   public async runNoClient(): Promise<CommandResult> {
     try {
-      let preparer = new UITestPreparer(this.artifactsDir, this.assemblyDir, this.appPath);
+      let preparer = new UITestPreparer(this.artifactsDir, this.buildDir, this.appPath);
 
       preparer.storeFile = this.storeFile;
       preparer.storePassword = this.storePassword;

--- a/src/commands/test/run/appium.ts
+++ b/src/commands/test/run/appium.ts
@@ -11,17 +11,12 @@ export default class RunAppiumTestsCommand extends RunTestsCommand {
   @hasArg
   buildDir: string;
 
-  @help("Path to Appium test project that should be built")
-  @longName("project-dir")
-  @hasArg
-  projectDir: string;
-
   constructor(args: CommandArgs) {
     super(args);
   }
 
   protected async prepareArtifactsDir(artifactsDir: string): Promise<string> {
-    let preparer = new AppiumPreparer(artifactsDir, this.projectDir, this.buildDir);
+    let preparer = new AppiumPreparer(artifactsDir, this.buildDir);
     preparer.include = parseIncludedFiles(this.include || []);
     preparer.testParameters = parseTestParameters(this.testParameters || []);
 

--- a/src/commands/test/run/calabash.ts
+++ b/src/commands/test/run/calabash.ts
@@ -10,7 +10,7 @@ export default class RunCalabashTestsCommand extends RunTestsCommand {
   @longName("workspace")
   @required
   @hasArg
-  workspace: string;
+  projectDir: string;
 
   @help("Use Signing Info for signing the test server")
   @longName("sign-info")
@@ -36,7 +36,7 @@ export default class RunCalabashTestsCommand extends RunTestsCommand {
   }
 
   protected async prepareArtifactsDir(artifactsDir: string): Promise<string> {
-    let preparer = new CalabashPreparer(artifactsDir, this.workspace, this.appPath);
+    let preparer = new CalabashPreparer(artifactsDir, this.projectDir, this.appPath);
 
     preparer.signInfo = this.signInfo;
     preparer.config = this.config;

--- a/src/commands/test/run/uitest.ts
+++ b/src/commands/test/run/uitest.ts
@@ -13,10 +13,10 @@ export default class RunUITestsCommand extends RunTestsCommand {
   appPath: string;
 
   @help("Path to directory with test assemblies")
-  @longName("assembly-dir")
+  @longName("build-dir")
   @required
   @hasArg
-  assemblyDir: string;
+  buildDir: string;
 
   @help("TODO")
   @longName("store-file")
@@ -53,7 +53,7 @@ export default class RunUITestsCommand extends RunTestsCommand {
   }
 
   protected async prepareArtifactsDir(artifactsDir: string): Promise<string> {
-    let preparer = new UITestPreparer(artifactsDir, this.assemblyDir, this.appPath);
+    let preparer = new UITestPreparer(artifactsDir, this.buildDir, this.appPath);
 
     preparer.storeFile = this.storeFile;
     preparer.storePassword = this.storePassword;

--- a/src/util/misc/promisfied-glob.ts
+++ b/src/util/misc/promisfied-glob.ts
@@ -26,6 +26,9 @@ export function globSingleFile(pattern: string, options?: g.Options): Promise<st
       else if (matches.length > 1) {
         reject(new Error(`Found more than one file that matches pattern "${pattern}`));
       }
+      else {
+        resolve(matches);
+      }
     });
   });
 }

--- a/src/util/misc/promisfied-glob.ts
+++ b/src/util/misc/promisfied-glob.ts
@@ -1,0 +1,31 @@
+import * as g from "glob";
+
+export function glob(pattern: string, options?: g.Options): Promise<string[]> {
+  return new Promise<string[]>((resolve, reject) => {
+    g(pattern, options, (err, matches) => {
+      if (err) {
+        reject(err);
+      }
+      else {
+        resolve(matches);
+      }
+    });
+  });
+}
+
+export function globSingleFile(pattern: string, options?: g.Options): Promise<string> {
+  return new Promise<string[]>((resolve, reject) => {
+    g(pattern, options, (err, matches) => {
+      if (err) {
+        reject(err);
+      }
+      
+      if (matches.length == 0) {
+        reject(new Error(`Cannot find any file that matches pattern "${pattern}"`));
+      }
+      else if (matches.length > 1) {
+        reject(new Error(`Found more than one file that matches pattern "${pattern}`));
+      }
+    });
+  });
+}

--- a/test/commands/test/lib/appium-preparer-test.ts
+++ b/test/commands/test/lib/appium-preparer-test.ts
@@ -41,7 +41,7 @@ describe("Preparing Appium workspace", () => {
 
     buildDir = await fsLayout.createLayout(spec);
 
-    let preparer = new AppiumPreparer(artifactsDir, null, buildDir);
+    let preparer = new AppiumPreparer(artifactsDir, buildDir);
     await expect(preparer.prepare()).to.eventually.be.rejected;
   });
 
@@ -51,7 +51,7 @@ describe("Preparing Appium workspace", () => {
 
     buildDir = await fsLayout.createLayout(spec);
 
-    let preparer = new AppiumPreparer(artifactsDir, null, buildDir);
+    let preparer = new AppiumPreparer(artifactsDir, buildDir);
     await expect(preparer.prepare()).to.eventually.be.rejected;
   });
 
@@ -61,7 +61,7 @@ describe("Preparing Appium workspace", () => {
 
     buildDir = await fsLayout.createLayout(spec);
 
-    let preparer = new AppiumPreparer(artifactsDir, null, buildDir);
+    let preparer = new AppiumPreparer(artifactsDir, buildDir);
     await expect(preparer.prepare()).to.eventually.be.rejected;
   });
 
@@ -71,7 +71,7 @@ describe("Preparing Appium workspace", () => {
 
     buildDir = await fsLayout.createLayout(spec);
 
-    let preparer = new AppiumPreparer(artifactsDir, null, buildDir);
+    let preparer = new AppiumPreparer(artifactsDir, buildDir);
     await expect(preparer.prepare()).to.eventually.be.rejected;
   });
 
@@ -79,7 +79,7 @@ describe("Preparing Appium workspace", () => {
     let spec = createValidBuildDirSpec();
     buildDir = await fsLayout.createLayout(spec);
     
-    let preparer = new AppiumPreparer(artifactsDir, null, buildDir);
+    let preparer = new AppiumPreparer(artifactsDir, buildDir);
     let manifestPath = await preparer.prepare();
 
     expect(manifestPath).to.eql(path.join(artifactsDir, "test-manifest.json"));


### PR DESCRIPTION
This PR unifies the following argument names for `prepare [framework]` and `run [framework]` commands:
  `--project-dir` for argument that points to the source directory. The current name is `--workspace` for Calabash.
  `--build-dir` for argument that points to the build directory. The current name is either `--build-dir` for Appium and Espresso, and `--assembly-dir` for Xamarin UI Tests.
