### PR TITLE
Test cloud calabash

### DIFF
--- a/src/commands/test/lib/appium-preparer.ts
+++ b/src/commands/test/lib/appium-preparer.ts
@@ -8,8 +8,6 @@ import * as pfs from "../../../util/misc/promisfied-fs";
 export class AppiumPreparer {
   private readonly artifactsDir: string;
   private buildDir: string;
-  public include: IFileDescriptionJson[];
-  public testParameters: { [key:string]: any };
 
   constructor(artifactsDir: string, buildDir: string) {
     if (!artifactsDir) {
@@ -117,18 +115,6 @@ export class AppiumPreparer {
         "data": { }
       }
     };
-
-    if (this.include) {
-      for (let i = 0; i < this.include.length; i++) {
-        
-        let includedFile = this.include[i];
-        let targetPath = path.join(this.artifactsDir, includedFile.targetPath);
-        await pfs.cp(includedFile.sourcePath, targetPath);
-        result.files.push(includedFile.targetPath);
-      }
-    }
-
-    _.merge(result.testFramework.data, this.testParameters || {}); 
 
     return result;
   }

--- a/src/commands/test/lib/calabash-preparer.ts
+++ b/src/commands/test/lib/calabash-preparer.ts
@@ -13,8 +13,6 @@ export class CalabashPreparer {
   public config: string;
   public profile: string;
   public skipConfigCheck: boolean;
-  public include: string[];
-  public testParameters: string[];
 
   constructor(artifactsDir: string, projectDir: string, appPath: string) {
     if (!artifactsDir) {
@@ -55,15 +53,7 @@ export class CalabashPreparer {
       command += ` --profile "${this.profile}"`;
     }
     if (this.skipConfigCheck) {
-      command += "--skip-config-check";
-    }
-
-    for (let i = 0; i < this.testParameters.length; i++) {
-      command += ` --test-parameters "${this.testParameters[i]}"`;
-    }
-
-    for (let i = 0; i < this.include.length; i++) {
-      command += ` --data "${this.include[i]}"`;
+      command += " --skip-config-check";
     }
 
     if (this.signInfo) {

--- a/src/commands/test/lib/espresso-preparer.ts
+++ b/src/commands/test/lib/espresso-preparer.ts
@@ -9,50 +9,42 @@ import * as pfs from "../../../util/misc/promisfied-fs";
 export class EspressoPreparer {
   private readonly artifactsDir: string;
   private buildDir: string;
-  private projectDir: string;
   private readonly testApkPath: string;
-  public include: IFileDescriptionJson[];
-  public testParameters: { [key:string]: any };
 
-  constructor(artifactsDir: string, projectDir?: string, buildDir?: string, testApkPath?: string) {
+  constructor(artifactsDir: string, buildDir: string, testApkPath?: string) {
     if (!artifactsDir) {
       throw new Error("Argument artifactsDir is required");
     }
+    if (!buildDir) {
+      throw new Error("Argument buildDir is required");
+    }
 
-    this.projectDir = projectDir;
     this.buildDir = buildDir;
     this.artifactsDir = artifactsDir;
     this.testApkPath = testApkPath;
   }
 
-  private validateEitherProjectBuildDirOrTestApkPath() {
-    if (this.projectDir && (this.buildDir || this.testApkPath)) {
-      throw new Error("You must not specify build dir if project dir or test apk path is specified.");
-    }
+  private validateEitherBuildDirOrTestApkPath() {
     if (this.buildDir && this.testApkPath) {
       throw new Error("You must not specify both build dir and test apk path.");
     }
-    if (!(this.projectDir || this.buildDir || this.testApkPath)) {
+    if (!(this.buildDir || this.testApkPath)) {
       throw new Error("Either projectDir, buildDir or testApkPath must be specified");
     }
   }
 
   public async prepare(): Promise<string> {
-    this.validateEitherProjectBuildDirOrTestApkPath();
-    if (this.projectDir) {
-      await this.validateProjectDir();
-      this.buildDir = await this.generateBuildDirFromProject();
-    }
-    else if (this.testApkPath) {
+    this.validateEitherBuildDirOrTestApkPath();
+    if (this.testApkPath) {
       await this.validatePathExists(
                     this.testApkPath,
                     true,
                     `File not found for test apk path: "${this.testApkPath}"`);
-      await pfs.copyFile(this.testApkPath, path.join(this.artifactsDir, path.basename(this.testApkPath)));
+      await pfs.cpFile(this.testApkPath, path.join(this.artifactsDir, path.basename(this.testApkPath)));
     }
     else {
       await this.validateBuildDir();
-      await pfs.copyDir(this.buildDir, this.artifactsDir);
+      await pfs.cpDir(this.buildDir, this.artifactsDir);
     }
     let manifestPath = path.join(this.artifactsDir, "test-manifest.json");
     let manifest = await this.createEspressoManifest();
@@ -62,19 +54,8 @@ export class EspressoPreparer {
     return manifestPath;
   }
 
-  private async validateProjectDir() {
-    await this.validatePathExists(
-      this.projectDir, 
-      false, 
-      `Project directory ${this.projectDir} doesn't exist`);
-  }
-
-  private async generateBuildDirFromProject(): Promise<string> {
-    throw new Error("Not implemented");
-  }
-
   private async validateBuildDir() {
-    await this.validateBuildDirExists();    
+    await this.validateBuildDirExists();
     await this.validateTestApkExists();
   }
 
@@ -144,18 +125,6 @@ export class EspressoPreparer {
         "data": { }
       }
     };
-
-    if (this.include) {
-      for (let i = 0; i < this.include.length; i++) {
-        
-        let includedFile = this.include[i];
-        let targetPath = path.join(this.artifactsDir, includedFile.targetPath);
-        await pfs.copy(includedFile.sourcePath, targetPath);
-        result.files.push(includedFile.targetPath);
-      }
-    }
-
-    _.merge(result.testFramework.data, this.testParameters || {}); 
 
     return result;
   }

--- a/src/commands/test/lib/prepare-tests-command.ts
+++ b/src/commands/test/lib/prepare-tests-command.ts
@@ -1,0 +1,98 @@
+import { Command, CommandArgs, CommandResult, 
+         help, success, name, shortName, longName, required, hasArg,
+         position, failure, notLoggedIn, ErrorCodes } from "../../../util/commandLine";
+import { out } from "../../../util/interaction";
+import { parseTestParameters } from "./parameters-parser";
+import { parseIncludedFiles } from "./included-files-parser";
+import { progressWithResult } from "./interaction";
+import { ITestCloudManifestJson, ITestFrameworkJson, IFileDescriptionJson } from "./test-manifest-reader";
+import * as _ from "lodash";
+import * as path from "path";
+import * as pfs from "../../../util/misc/promisfied-fs";
+
+export class PrepareTestsCommand extends Command {
+  
+  @help("Path to output directory where all test files will be copied")
+  @longName("artifacts-dir")
+  @hasArg
+  artifactsDir: string;
+
+  @help("Additional files / directories that should be included in the test run. The value should be in format 'sourceDir=targetDir'")
+  @longName("include")
+  @hasArg
+  include: string[];
+
+  @help("Additional test parameters that should be included in the test run. The value should be in format key=value")
+  @longName("test-parameter")
+  @shortName("p")
+  @hasArg
+  testParameters: string[];
+
+  constructor(args: CommandArgs) {
+    super(args);
+
+    if (typeof this.testParameters === "string") {
+      this.testParameters = [ this.testParameters ];
+    }
+
+    if (typeof this.include === "string") {
+      this.include = [ this.include ];
+    }
+  }
+
+  public async runNoClient(): Promise<CommandResult> {
+    try {
+      let manifestPath = await progressWithResult("Preparing tests", this.prepareManifest());
+      await this.addIncludedFilesAndTestParametersToManifest(manifestPath);
+      out.text(this.getSuccessMessage(manifestPath));
+
+      return success();
+    }
+    catch (err) {
+      return failure(ErrorCodes.Exception, err.message);
+    }
+  }
+
+  private async addIncludedFilesAndTestParametersToManifest(manifestPath: string): Promise<void> {
+    let manifestJson = await pfs.readFile(manifestPath, "utf8"); 
+    let manifest = JSON.parse(manifestJson) as ITestCloudManifestJson;
+    
+    await this.addIncludedFiles(manifest);
+    await this.addTestParameters(manifest);
+
+    let modifiedJson = JSON.stringify(manifest, null, 1);
+    await pfs.writeFile(manifestPath, modifiedJson);
+  }
+
+  protected async addIncludedFiles(manifest: ITestCloudManifestJson): Promise<void> {
+    if (!this.include) {
+      return;
+    }
+
+    let includedFiles = parseIncludedFiles(this.include);
+    for (let i = 0; i < includedFiles.length; i++) {
+      let includedFile = includedFiles[i];
+      let copyTarget = path.join(this.artifactsDir, includedFile.targetPath);
+      await pfs.cp(includedFile.sourcePath, copyTarget);
+
+      manifest.files.push(includedFile.targetPath);
+    }
+  } 
+
+  protected async addTestParameters(manifest: ITestCloudManifestJson): Promise<void> {
+    if (!this.testParameters) {
+      return;
+    }
+
+    let parsedParameters = parseTestParameters(this.testParameters);
+    _.merge(manifest.testFramework.data, parsedParameters || {});
+  }
+
+  protected prepareManifest(): Promise<string> {
+    throw new Error("This method must be overriden in derived classes");
+  }
+
+  protected getSuccessMessage(manifestPath: string) {
+    return `Tests are ready to run. Manifest file was written to ${manifestPath}`;
+  }
+}

--- a/src/commands/test/lib/uitest-preparer.ts
+++ b/src/commands/test/lib/uitest-preparer.ts
@@ -18,8 +18,6 @@ export class UITestPreparer {
   public keyAlias: string;
   public keyPassword: string;
   public signInfo: string;
-  public include: string[];
-  public testParameters: string[];
   public uiTestToolsDir: string;
 
   constructor(artifactsDir: string, buildDir: string, appPath: string) {
@@ -74,14 +72,6 @@ export class UITestPreparer {
     }
 
     command += ` --assembly-dir "${this.buildDir}" --artifacts-dir "${this.artifactsDir}"`;
-
-    for (let i = 0; i < this.testParameters.length; i++) {
-      command += ` --test-parameter "${this.testParameters[i]}"`;
-    }
-
-    for (let i = 0; i < this.include.length; i++) {
-      command += ` --include "${this.include[i]}"`;
-    }
 
     if (this.signInfo) {
       command += ` --sign-info "${this.signInfo}"`;

--- a/src/commands/test/prepare/appium.ts
+++ b/src/commands/test/prepare/appium.ts
@@ -1,58 +1,23 @@
-import { Command, CommandArgs, CommandResult, 
-         help, success, name, shortName, longName, required, hasArg,
-         position, failure, notLoggedIn, ErrorCodes } from "../../../util/commandLine";
+import { CommandArgs, help, success, name, longName, required, hasArg,
+         ErrorCodes } from "../../../util/commandLine";
 import { AppiumPreparer } from "../lib/appium-preparer";
+import { PrepareTestsCommand } from "../lib/prepare-tests-command";
 import { out } from "../../../util/interaction";
-import { parseTestParameters } from "../lib/parameters-parser";
-import { parseIncludedFiles } from "../lib/included-files-parser";
 
 @help("Prepares Appium artifacts for test run")
-export default class PrepareAppiumCommand extends Command {
-  @help("Path to output directory where all test files will be copied")
-  @longName("artifacts-dir")
-  @hasArg
-  artifactsDir: string;
-
+export default class PrepareAppiumCommand extends PrepareTestsCommand {
   @help("Path to Appium output directory (usually target/upload)")
   @longName("build-dir")
   @hasArg
+  @required
   buildDir: string;
-
-  @help("Additional files / directories that should be included in the test run. The value should be in format 'sourceDir=targetDir'")
-  @longName("include")
-  @hasArg
-  include: string[];
-
-  @help("Additional test parameters that should be included in the test run. The value should be in format key=value")
-  @longName("test-parameter")
-  @shortName("p")
-  @hasArg
-  testParameters: string[];
 
   constructor(args: CommandArgs) {
     super(args);
-
-    if (typeof this.testParameters === "string") {
-      this.testParameters = [ this.testParameters ];
-    }
-
-    if (typeof this.include === "string") {
-      this.include = [ this.include ];
-    }
   }
 
-  public async runNoClient(): Promise<CommandResult> {
-    try {
-      let preparer = new AppiumPreparer(this.artifactsDir, this.buildDir);
-      preparer.include = parseIncludedFiles(this.include || []);
-      preparer.testParameters = parseTestParameters(this.testParameters || []);
-
-      let manifestPath = await preparer.prepare();
-      out.text(`Appium tests are ready to run. Manifest file was written to ${manifestPath}.`);
-      return success();
-    } 
-    catch (err) {
-      return failure(ErrorCodes.Exception, err.message);
-    }
+  protected prepareManifest(): Promise<string> {
+    let preparer = new AppiumPreparer(this.artifactsDir, this.buildDir);
+    return preparer.prepare();
   }
 }

--- a/src/commands/test/prepare/calabash.ts
+++ b/src/commands/test/prepare/calabash.ts
@@ -1,7 +1,7 @@
-import { Command, CommandArgs, CommandResult,
-         help, success, name, shortName, longName, required, hasArg,
-         position, failure, notLoggedIn, ErrorCodes } from "../../../util/commandLine";
+import { CommandArgs, help, success, name, longName, required, hasArg,
+         ErrorCodes } from "../../../util/commandLine";
 import { CalabashPreparer } from "../lib/calabash-preparer";
+import { PrepareTestsCommand } from "../lib/prepare-tests-command";
 import { out } from "../../../util/interaction";
 import * as outExtensions from "../lib/interaction";
 import * as process from "../../../util/misc/process-helper";
@@ -9,7 +9,7 @@ import * as process from "../../../util/misc/process-helper";
 const debug = require("debug")("mobile-center-cli:commands:test:prepare:calabash");
 
 @help("Prepares Calabash artifacts for test run")
-export default class PrepareCalabashCommand extends Command {
+export default class PrepareCalabashCommand extends PrepareTestsCommand {
   @help("Path to an application file")
   @longName("app-path")
   @required
@@ -22,27 +22,10 @@ export default class PrepareCalabashCommand extends Command {
   @hasArg
   projectDir: string;
 
-  @help("Path to output directory with all test artifacts")
-  @longName("artifacts-dir")
-  @required
-  @hasArg
-  artifactsDir: string;
-
   @help("Use Signing Info for signing the test server")
   @longName("sign-info")
   @hasArg
   signInfo: string;
-
-  @help("Additional files / directories that should be included in the test run. The value should be in format 'sourceDir=targetDir'")
-  @longName("include")
-  @hasArg
-  include: string[];
-
-  @help("Additional test parameters that should be included in the test run. The value should be in format key=value")
-  @longName("test-parameter")
-  @shortName("p")
-  @hasArg
-  testParameters: string[];
 
   @help("Path to Cucumber configuration. Can be relative to workspace")
   @longName("config")
@@ -60,41 +43,16 @@ export default class PrepareCalabashCommand extends Command {
 
   constructor(args: CommandArgs) {
     super(args);
-
-    if (!this.testParameters) {
-      this.testParameters = [];
-    }
-    else if (typeof this.testParameters === "string") {
-      this.testParameters = [ this.testParameters ];
-    }
-
-    if (!this.include) {
-      this.include = [];
-    }
-    else if (typeof this.include === "string") {
-      this.include = [ this.include ];
-    }
   }
 
-  public async runNoClient(): Promise<CommandResult> {
-    try {
-      let preparer = new CalabashPreparer(this.artifactsDir, this.projectDir, this.appPath);
+  protected prepareManifest(): Promise<string> {
+    let preparer = new CalabashPreparer(this.artifactsDir, this.projectDir, this.appPath);
 
       preparer.signInfo = this.signInfo;
       preparer.config = this.config;
       preparer.profile = this.profile;
       preparer.skipConfigCheck = this.skipConfigCheck;
-      preparer.include = this.include;
-      preparer.testParameters = this.testParameters;
 
-      let manifestPath = await preparer.prepare();
-      out.text(`Calabash tests are ready to run. Manifest file was written to ${manifestPath}.`);
-
-      return success();
-    }
-    catch (err) {
-      let exitCode = err.exitCode || ErrorCodes.Exception;
-      return failure(exitCode, err.message);
-    }
+      return preparer.prepare();
   }
 }

--- a/src/commands/test/prepare/espresso.ts
+++ b/src/commands/test/prepare/espresso.ts
@@ -1,63 +1,27 @@
-import { Command, CommandArgs, CommandResult, 
-         help, success, name, shortName, longName, required, hasArg,
-         position, failure, notLoggedIn, ErrorCodes } from "../../../util/commandLine";
+import { CommandArgs, help, success, name, shortName, longName, required, hasArg,
+         ErrorCodes } from "../../../util/commandLine";
 import { EspressoPreparer } from "../lib/espresso-preparer";
+import { PrepareTestsCommand } from "../lib/prepare-tests-command";
 import { out } from "../../../util/interaction";
-import { parseTestParameters } from "../lib/parameters-parser";
-import { parseIncludedFiles } from "../lib/included-files-parser";
 
 @help("Prepares Espresso artifacts for test run")
-export default class PrepareEspressoCommand extends Command {
-  @help("Path to output directory where all test files will be copied")
-  @longName("artifacts-dir")
-  @hasArg
-  artifactsDir: string;
-
+export default class PrepareEspressoCommand extends PrepareTestsCommand {
   @help("Path to Espresso output directory (usually <project>/build/outputs/apk)")
   @longName("build-dir")
   @hasArg
   buildDir: string;
 
-  @help("Path to Espresso test project that should be built")
-  @longName("project-dir")
+  @help("Path to Espresso tests .apk file (default uses build-dir to detect this file)")
+  @longName("test-apk-path")
   @hasArg
-  projectDir: string;
-
-  @help("Additional files / directories that should be included in the test run. The value should be in format 'sourceDir=targetDir'")
-  @longName("include")
-  @hasArg
-  include: string[];
-
-  @help("Additional test parameters that should be included in the test run. The value should be in format key=value")
-  @longName("test-parameter")
-  @shortName("p")
-  @hasArg
-  testParameters: string[];
+  testApkPath: string;
 
   constructor(args: CommandArgs) {
     super(args);
-
-    if (typeof this.testParameters === "string") {
-      this.testParameters = [ this.testParameters ];
-    }
-
-    if (typeof this.include === "string") {
-      this.include = [ this.include ];
-    }
   }
 
-  public async runNoClient(): Promise<CommandResult> {
-    try {
-      let preparer = new EspressoPreparer(this.artifactsDir, this.projectDir, this.buildDir);
-      preparer.include = parseIncludedFiles(this.include || []);
-      preparer.testParameters = parseTestParameters(this.testParameters || []);
-
-      let manifestPath = await preparer.prepare();
-      out.text(`Espresso tests are ready to run. Manifest file was written to ${manifestPath}.`);
-      return success();
-    } 
-    catch (err) {
-      return failure(ErrorCodes.Exception, err.message);
-    }
+  protected prepareManifest(): Promise<string> {
+    let preparer = new EspressoPreparer(this.artifactsDir, this.buildDir, this.testApkPath);
+    return preparer.prepare();
   }
 }

--- a/src/commands/test/prepare/uitest.ts
+++ b/src/commands/test/prepare/uitest.ts
@@ -1,7 +1,7 @@
-import { Command, CommandArgs, CommandResult,
-         help, success, name, shortName, longName, required, hasArg,
-         position, failure, notLoggedIn, ErrorCodes } from "../../../util/commandLine";
+import { CommandArgs, help, success, name, shortName, longName, required, hasArg,
+         ErrorCodes } from "../../../util/commandLine";
 import { UITestPreparer } from "../lib/uitest-preparer";
+import { PrepareTestsCommand } from "../lib/prepare-tests-command";
 import { out } from "../../../util/interaction";
 import * as outExtensions from "../lib/interaction";
 import * as process from "../../../util/misc/process-helper";
@@ -9,7 +9,7 @@ import * as process from "../../../util/misc/process-helper";
 const debug = require("debug")("mobile-center-cli:commands:tests:prepare");
 
 @help("Prepares UI Test artifacts for test run")
-export default class PrepareUITestCommand extends Command {
+export default class PrepareUITestCommand extends PrepareTestsCommand {
   @help("Path to an application file")
   @longName("app-path")
   @required
@@ -21,12 +21,6 @@ export default class PrepareUITestCommand extends Command {
   @required
   @hasArg
   buildDir: string;
-
-  @help("Path to output directory with all test artifacts")
-  @longName("artifacts-dir")
-  @required
-  @hasArg
-  artifactsDir: string;
 
   @help("TODO")
   @longName("store-file")
@@ -58,55 +52,19 @@ export default class PrepareUITestCommand extends Command {
   @hasArg
   uiTestToolsDir: string;
 
-  @help("Additional files / directories that should be included in the test run. The value should be in format 'sourceDir=targetDir'")
-  @longName("include")
-  @hasArg
-  include: string[];
-
-  @help("Additional test parameters that should be included in the test run. The value should be in format key=value")
-  @longName("test-parameter")
-  @shortName("p")
-  @hasArg
-  testParameters: string[];
-
   constructor(args: CommandArgs) {
     super(args);
-
-    if (!this.testParameters) {
-      this.testParameters = [];
-    }
-    else if (typeof this.testParameters === "string") {
-      this.testParameters = [ this.testParameters ];
-    }
-
-    if (!this.include) {
-      this.include = [];
-    }
-    else if (typeof this.include === "string") {
-      this.include = [ this.include ];
-    }
   }
 
-  public async runNoClient(): Promise<CommandResult> {
-    try {
-      let preparer = new UITestPreparer(this.artifactsDir, this.buildDir, this.appPath);
+  protected prepareManifest(): Promise<string> {
+    let preparer = new UITestPreparer(this.artifactsDir, this.buildDir, this.appPath);
 
-      preparer.storeFile = this.storeFile;
-      preparer.storePassword = this.storePassword;
-      preparer.keyAlias = this.keyAlias;
-      preparer.keyPassword = this.keyPassword;
-      preparer.include = this.include;
-      preparer.testParameters = this.testParameters;
-      preparer.uiTestToolsDir = this.uiTestToolsDir;
+    preparer.storeFile = this.storeFile;
+    preparer.storePassword = this.storePassword;
+    preparer.keyAlias = this.keyAlias;
+    preparer.keyPassword = this.keyPassword;
+    preparer.uiTestToolsDir = this.uiTestToolsDir;
 
-      let manifestPath = await preparer.prepare();
-      out.text(`UI Tests are ready to run. Manifest file was written to ${manifestPath}.`);
-
-      return success();
-    }
-    catch (err) {
-      let exitCode = err.exitCode || ErrorCodes.Exception;
-      return failure(exitCode, err.message);
-    }
+    return preparer.prepare();
   }
 }

--- a/src/commands/test/run/appium.ts
+++ b/src/commands/test/run/appium.ts
@@ -15,11 +15,8 @@ export default class RunAppiumTestsCommand extends RunTestsCommand {
     super(args);
   }
 
-  protected async prepareArtifactsDir(artifactsDir: string): Promise<string> {
+  protected prepareManifest(artifactsDir: string): Promise<string> {
     let preparer = new AppiumPreparer(artifactsDir, this.buildDir);
-    preparer.include = parseIncludedFiles(this.include || []);
-    preparer.testParameters = parseTestParameters(this.testParameters || []);
-
-    return await preparer.prepare();
+    return preparer.prepare();
   }
 }

--- a/src/commands/test/run/calabash.ts
+++ b/src/commands/test/run/calabash.ts
@@ -35,16 +35,14 @@ export default class RunCalabashTestsCommand extends RunTestsCommand {
     super(args);
   }
 
-  protected async prepareArtifactsDir(artifactsDir: string): Promise<string> {
+  protected prepareManifest(artifactsDir: string): Promise<string> {
     let preparer = new CalabashPreparer(artifactsDir, this.projectDir, this.appPath);
 
     preparer.signInfo = this.signInfo;
     preparer.config = this.config;
     preparer.profile = this.profile;
     preparer.skipConfigCheck = this.skipConfigCheck;
-    preparer.include = this.include;
-    preparer.testParameters = this.testParameters;
 
-    return await preparer.prepare();
+    return preparer.prepare();
   }
 }

--- a/src/commands/test/run/espresso.ts
+++ b/src/commands/test/run/espresso.ts
@@ -18,12 +18,6 @@ export default class RunEspressoTestsCommand extends RunTestsCommand {
   @hasArg
   buildDir: string;
 
-  @help("Path to Espresso test project that should be built")
-  @longName("project-dir")
-  @hasArg
-  projectDir: string;
-
-
   @help("Path to Espresso tests .apk file (default uses build-dir to detect this file)")
   @longName("test-apk-path")
   @hasArg
@@ -33,14 +27,11 @@ export default class RunEspressoTestsCommand extends RunTestsCommand {
     super(args);
   }
 
-  protected async prepareArtifactsDir(artifactsDir: string): Promise<string> {
+  protected prepareArtifactsDir(artifactsDir: string): Promise<string> {
     if (!this.appPath) {
       throw new Error("Argument --app-path is required");
     }
-    let preparer = new EspressoPreparer(artifactsDir, this.projectDir, this.buildDir, this.testApkPath);
-    preparer.include = parseIncludedFiles(this.include || []);
-    preparer.testParameters = parseTestParameters(this.testParameters || []);
-
-    return await preparer.prepare();
+    let preparer = new EspressoPreparer(artifactsDir, this.buildDir, this.testApkPath);
+    return preparer.prepare();
   }
 }

--- a/src/commands/test/run/manifest.ts
+++ b/src/commands/test/run/manifest.ts
@@ -18,7 +18,7 @@ export default class RunManifestTestsCommand extends RunTestsCommand {
     return path.dirname(this.manifestPath);
   }
 
-  protected async prepareArtifactsDir(artifactsDir: string): Promise<string> {
+  protected async prepareManifest(artifactsDir: string): Promise<string> {
     return this.manifestPath;
   }
 

--- a/src/commands/test/run/uitest.ts
+++ b/src/commands/test/run/uitest.ts
@@ -52,17 +52,15 @@ export default class RunUITestsCommand extends RunTestsCommand {
     super(args);
   }
 
-  protected async prepareArtifactsDir(artifactsDir: string): Promise<string> {
+  protected prepareManifest(artifactsDir: string): Promise<string> {
     let preparer = new UITestPreparer(artifactsDir, this.buildDir, this.appPath);
 
     preparer.storeFile = this.storeFile;
     preparer.storePassword = this.storePassword;
     preparer.keyAlias = this.keyAlias;
     preparer.keyPassword = this.keyPassword;
-    preparer.include = this.include;
-    preparer.testParameters = this.testParameters;
     preparer.uiTestToolsDir = this.uiTestToolsDir;
 
-    return await preparer.prepare();
+    return preparer.prepare();
   }
 }

--- a/src/util/misc/promisfied-fs.ts
+++ b/src/util/misc/promisfied-fs.ts
@@ -17,6 +17,13 @@ export async function read(fd: number, buffer: Buffer, offset: number, length: n
   return { bytesRead: result[0], buffer: result[1] };
 }
 
+export function readFile(filename: string): Promise<Buffer>;
+export function readFile(filename: string, encoding: string): Promise<string>;
+export function readFile(filename: string, options: { flag?: string; }): Promise<Buffer>;
+export async function readFile(filename: string, options?: string | { encoding: string; flag?: string; }): Promise<string> {
+  return (await callFs(fs.readFile, filename, options))[0];
+};
+
 export async function readdir(path: string | Buffer): Promise<string[]> {
   return (await callFs(fs.readdir, path))[0];
 }


### PR DESCRIPTION
## Processing `--include` and `--test-parameter` arguments directly in the CLI
All `prepare` commands share two command line arguments: 
1. `--include`. This allows user to add additional files to the Test Cloud upload.
2. `--test-parameter`. This allows user to add additional test parameters to the manifest.

In the current version, these parameters are passed to external `prepare` process (for frameworks that need it). That process parses them, copies to the artifacts directory, and saves appropriate information to the test manifest.
That has two problems:
1. We need to implement parsing and validation multiple times.
2. It is very easy to get inconsistent behavior. For example, the Calabash prepare command separates key / values by using colon (':'), while other frameworks use equal sign ('=').

This PR fixes that. Now the CLI itself is reponsible for processing test parameters and included files. The logic is in new class - `PrepareTestsCommands` - which is a base class for all prepare commands.

## Removing `--project-dir` argument from Appium and Espresso prepare commands.
Handling this argument is not implemented yet. I'm removing it, so users are not tempted to use it.