### PR TITLE
Test Cloud: support for relative paths in --include argument

### DIFF
--- a/src/commands/test/lib/included-files-parser.ts
+++ b/src/commands/test/lib/included-files-parser.ts
@@ -1,17 +1,68 @@
 import { IFileDescriptionJson } from "./test-manifest-reader";
+import * as path from "path";
 
-export function parseIncludedFiles(includedFiles: string[]): IFileDescriptionJson[] {
-  return includedFiles.map(f => parseIncludedFile(f));
+const invalidCharactersRegexp = /['"!#$%&+^<=>`|]/
+
+export function parseIncludedFiles(includedFiles: string[], rootDir: string): IFileDescriptionJson[] {
+  return includedFiles.map(f => parseIncludedFile(f, rootDir));
 }
 
-function parseIncludedFile(includedFile: string): IFileDescriptionJson {
+function parseIncludedFile(includedFile: string, rootDir: string): IFileDescriptionJson {
   let separatorIndex = includedFile.indexOf("=");
   if (separatorIndex === -1) {
-    throw new Error(`Invalid definition of included files: ${includedFile}. Included files must specified in format "targetPath"="sourcePath"`);
+    return parseIncludedFileFromSinglePath(includedFile, rootDir);
+  }
+  else {
+    return parseIncludedFileFromPathsPair(includedFile, rootDir, separatorIndex);
+  }
+}
+
+function parseIncludedFileFromSinglePath(includedFile: string, rootDir: string): IFileDescriptionJson {
+  validatePath(includedFile);
+
+  if (path.isAbsolute(includedFile)) {
+    let targetPath = path.relative(rootDir, includedFile);
+    if (targetPath.indexOf("..") != -1) {
+      throw new Error(`Invalid included file: "${includedFile}". ` + 
+                      `If only a single path is used, it must be inside directory "${rootDir}"`);
+    }
+
+    return {
+      targetPath: path.relative(rootDir, includedFile),
+      sourcePath: includedFile
+    }
+  }
+  else {
+    return {
+      targetPath: includedFile,
+      sourcePath: path.join(rootDir, includedFile)
+    }
+  }
+}
+
+function parseIncludedFileFromPathsPair(includedFile: string, rootDir: string, separatorIndex: number): IFileDescriptionJson {
+  let targetPath = includedFile.substr(0, separatorIndex);
+  let sourcePath = includedFile.substr(separatorIndex + 1, includedFile.length - separatorIndex - 1);
+
+  validatePath(targetPath);
+  validatePath(sourcePath);
+
+  if (path.isAbsolute(targetPath)) {
+    throw new Error(`Invalid included file: "${includedFile}". Target path must be relative`); 
+  }
+
+  if (!path.isAbsolute(sourcePath)) {
+    sourcePath = path.join(rootDir, sourcePath);
   }
 
   return {
-    targetPath: includedFile.substr(0, separatorIndex),
-    sourcePath: includedFile.substr(separatorIndex + 1, includedFile.length - separatorIndex - 1)
+    targetPath: targetPath,
+    sourcePath: sourcePath
   };
+}
+
+function validatePath(possiblePath: string) {
+  if (invalidCharactersRegexp.test(possiblePath)) {
+    throw new Error(`Invalid path: "${possiblePath}"`);
+  }
 }

--- a/src/commands/test/lib/prepare-tests-command.ts
+++ b/src/commands/test/lib/prepare-tests-command.ts
@@ -69,7 +69,7 @@ export class PrepareTestsCommand extends Command {
       return;
     }
 
-    let includedFiles = parseIncludedFiles(this.include);
+    let includedFiles = parseIncludedFiles(this.include, this.getSourceRootDir());
     for (let i = 0; i < includedFiles.length; i++) {
       let includedFile = includedFiles[i];
       let copyTarget = path.join(this.artifactsDir, includedFile.targetPath);
@@ -94,5 +94,9 @@ export class PrepareTestsCommand extends Command {
 
   protected getSuccessMessage(manifestPath: string) {
     return `Tests are ready to run. Manifest file was written to ${manifestPath}`;
+  }
+
+  protected getSourceRootDir(): string {
+    throw new Error("This method must be overriden in derived classes");
   }
 }

--- a/src/commands/test/lib/run-tests-command.ts
+++ b/src/commands/test/lib/run-tests-command.ts
@@ -124,6 +124,10 @@ export class RunTestsCommand extends AppCommand {
     throw new Error("This method must be overriden in derived classes");
   }
 
+  protected getSourceRootDir(): string {
+    throw new Error("This method must be overriden in derived classes");
+  }
+
   protected async cleanupArtifactsDir(artifactsDir: string): Promise<void> {
     await pfs.rmDir(artifactsDir, true);
   }
@@ -171,7 +175,7 @@ export class RunTestsCommand extends AppCommand {
       return;
     }
 
-    let includedFiles = parseIncludedFiles(this.include);
+    let includedFiles = parseIncludedFiles(this.include, this.getSourceRootDir());
     for (let i = 0; i < includedFiles.length; i++) {
       let includedFile = includedFiles[i];
       let copyTarget = path.join(artifactsDir, includedFile.targetPath);

--- a/src/commands/test/prepare/appium.ts
+++ b/src/commands/test/prepare/appium.ts
@@ -20,4 +20,8 @@ export default class PrepareAppiumCommand extends PrepareTestsCommand {
     let preparer = new AppiumPreparer(this.artifactsDir, this.buildDir);
     return preparer.prepare();
   }
+
+  protected getSourceRootDir() {
+    return this.buildDir;
+  }
 }

--- a/src/commands/test/prepare/calabash.ts
+++ b/src/commands/test/prepare/calabash.ts
@@ -55,4 +55,8 @@ export default class PrepareCalabashCommand extends PrepareTestsCommand {
 
       return preparer.prepare();
   }
+
+  protected getSourceRootDir() {
+    return this.projectDir;
+  }
 }

--- a/src/commands/test/prepare/espresso.ts
+++ b/src/commands/test/prepare/espresso.ts
@@ -24,4 +24,8 @@ export default class PrepareEspressoCommand extends PrepareTestsCommand {
     let preparer = new EspressoPreparer(this.artifactsDir, this.buildDir, this.testApkPath);
     return preparer.prepare();
   }
+
+  protected getSourceRootDir() {
+    return this.buildDir;
+  }
 }

--- a/src/commands/test/prepare/uitest.ts
+++ b/src/commands/test/prepare/uitest.ts
@@ -67,4 +67,8 @@ export default class PrepareUITestCommand extends PrepareTestsCommand {
 
     return preparer.prepare();
   }
+
+  protected getSourceRootDir() {
+    return this.buildDir;
+  }
 }

--- a/src/commands/test/run/appium.ts
+++ b/src/commands/test/run/appium.ts
@@ -19,4 +19,8 @@ export default class RunAppiumTestsCommand extends RunTestsCommand {
     let preparer = new AppiumPreparer(artifactsDir, this.buildDir);
     return preparer.prepare();
   }
+  
+  protected getSourceRootDir() {
+    return this.buildDir;
+  }
 }

--- a/src/commands/test/run/calabash.ts
+++ b/src/commands/test/run/calabash.ts
@@ -45,4 +45,8 @@ export default class RunCalabashTestsCommand extends RunTestsCommand {
 
     return preparer.prepare();
   }
+
+  protected getSourceRootDir() {
+    return this.projectDir;
+  }
 }

--- a/src/commands/test/run/espresso.ts
+++ b/src/commands/test/run/espresso.ts
@@ -34,4 +34,8 @@ export default class RunEspressoTestsCommand extends RunTestsCommand {
     let preparer = new EspressoPreparer(artifactsDir, this.buildDir, this.testApkPath);
     return preparer.prepare();
   }
+
+  protected getSourceRootDir() {
+    return this.buildDir;
+  }
 }

--- a/src/commands/test/run/uitest.ts
+++ b/src/commands/test/run/uitest.ts
@@ -63,4 +63,8 @@ export default class RunUITestsCommand extends RunTestsCommand {
 
     return preparer.prepare();
   }
+
+  protected getSourceRootDir() {
+    return this.buildDir;
+  }
 }

--- a/test/commands/test/lib/included-files-parser-test.ts
+++ b/test/commands/test/lib/included-files-parser-test.ts
@@ -1,10 +1,11 @@
 import { IFileDescriptionJson } from "../../../../src/commands/test/lib/test-manifest-reader";
 import { expect } from "chai";
 import { parseIncludedFiles } from "../../../../src/commands/test/lib/included-files-parser";
+import * as os from "os";
 
 describe("parseIncludedFiles", () => {
   let windowsRootDir = "d:\\workspace";
-  let unitRootDir = "/home/user/workspace";
+  let unixRootDir = "/home/user/workspace";
 
   function normalizePath(path: string): string {
     return path.replace(/\\/g, "/");
@@ -20,22 +21,61 @@ describe("parseIncludedFiles", () => {
   }
 
   it("should parse pairs with relative target path and valid source path", () => {
-    let rawIncludedFiles = [ "data\\foo=d:\\Temp\\Data", "data\\bar=bar" ];
-    let parsedIncludedFiles = normalizeFileDescriptions(parseIncludedFiles(rawIncludedFiles, windowsRootDir));
+    let rawIncludedFiles: string[] = null;
+    let expected: any[] = null;
+    let rootDir: string = null;
+
+    if (os.platform() === "win32") {
+      rawIncludedFiles = [ "data\\foo=d:\\Temp\\Data", "data\\bar=bar" ];
+
+      expected = [
+        {
+          "targetPath": "data/foo",
+          "sourcePath": "d:/Temp/Data"
+        },
+        {
+          "targetPath": "data/bar",
+          "sourcePath": "d:/workspace/bar"
+        }
+      ];
+
+      rootDir = windowsRootDir;
+    }
+    else {
+      rawIncludedFiles = [ "data/foo=/tmp/data", "data/bar=bar" ];
+
+      expected = [
+        {
+          "targetPath": "data/foo",
+          "sourcePath": "/tmp/data"
+        },
+        {
+          "targetPath": "data/bar",
+          "sourcePath": "/home/user/workspace/bar"
+        }
+      ];
+
+      rootDir = unixRootDir;
+    }
+
+    let parsedIncludedFiles = normalizeFileDescriptions(parseIncludedFiles(rawIncludedFiles, rootDir));
+    expect(parsedIncludedFiles).to.deep.equal(expected);
+  });
+
+  it("should accept single absolute, deep path under root dir", () => {
+    let rawIncludedFiles = [ "/home/user/workspace/somewhere/myAbsoluteData" ];
+    let parsedIncludedFiles = normalizeFileDescriptions(parseIncludedFiles(rawIncludedFiles, unixRootDir));
 
     let expected = [
       {
-        "targetPath": "data/foo",
-        "sourcePath": "d:/Temp/Data"
-      },
-      {
-        "targetPath": "data/bar",
-        "sourcePath": "d:/workspace/bar"
+        "targetPath": "somewhere/myAbsoluteData",
+        "sourcePath": "/home/user/workspace/somewhere/myAbsoluteData"
       }
     ];
 
     expect(parsedIncludedFiles).to.deep.equal(expected);
   });
+
 
   it("should reject pairs with invalid target path", () => {
     expect(() => {
@@ -57,7 +97,7 @@ describe("parseIncludedFiles", () => {
 
   it("should accept single relative path or absolute path under root dir", () => {
     let rawIncludedFiles = [ "myRelativeData", "/home/user/workspace/myAbsoluteData" ];
-    let parsedIncludedFiles = normalizeFileDescriptions(parseIncludedFiles(rawIncludedFiles, unitRootDir));
+    let parsedIncludedFiles = normalizeFileDescriptions(parseIncludedFiles(rawIncludedFiles, unixRootDir));
 
     let expected = [
       {
@@ -75,7 +115,13 @@ describe("parseIncludedFiles", () => {
 
   it("should reject single absolute dir that is not under root dir", () => {
     expect(() => {
-      parseIncludedFiles(["/tmp/source"], unitRootDir)
+      parseIncludedFiles(["/tmp/source"], unixRootDir)
+    }).to.throw();
+  });
+
+  it("should reject single absolute dir that is parent of root dir", () => {
+    expect(() => {
+      parseIncludedFiles(["/home/user"], unixRootDir)
     }).to.throw();
   });
 

--- a/test/commands/test/lib/included-files-parser-test.ts
+++ b/test/commands/test/lib/included-files-parser-test.ts
@@ -1,22 +1,87 @@
+import { IFileDescriptionJson } from "../../../../src/commands/test/lib/test-manifest-reader";
 import { expect } from "chai";
 import { parseIncludedFiles } from "../../../../src/commands/test/lib/included-files-parser";
 
 describe("parseIncludedFiles", () => {
-  it("should parse included files", () => {
-    let rawIncludedFiles = [ "data\\foo=d:\\Temp\\Data", "data/bar=/tmp/test-data" ];
-    let parsedIncludedFiles = parseIncludedFiles(rawIncludedFiles);
+  let windowsRootDir = "d:\\workspace";
+  let unitRootDir = "/home/user/workspace";
+
+  function normalizePath(path: string): string {
+    return path.replace(/\\/g, "/");
+  }
+
+  function normalizeFileDescriptions(descriptions: IFileDescriptionJson[]): IFileDescriptionJson[] {
+    return descriptions.map(d => {
+      return {
+        "targetPath": normalizePath(d.targetPath),
+        "sourcePath": normalizePath(d.sourcePath)
+      };
+    })
+  }
+
+  it("should parse pairs with relative target path and valid source path", () => {
+    let rawIncludedFiles = [ "data\\foo=d:\\Temp\\Data", "data\\bar=bar" ];
+    let parsedIncludedFiles = normalizeFileDescriptions(parseIncludedFiles(rawIncludedFiles, windowsRootDir));
 
     let expected = [
       {
-        "targetPath": "data\\foo",
-        "sourcePath": "d:\\Temp\\Data"
+        "targetPath": "data/foo",
+        "sourcePath": "d:/Temp/Data"
       },
       {
         "targetPath": "data/bar",
-        "sourcePath": "/tmp/test-data"
+        "sourcePath": "d:/workspace/bar"
       }
     ];
 
     expect(parsedIncludedFiles).to.deep.equal(expected);
+  });
+
+  it("should reject pairs with invalid target path", () => {
+    expect(() => {
+      parseIncludedFiles(["\"|ff=bar"], windowsRootDir)
+    }).to.throw();
+  });
+
+  it("should reject pairs with invalid source path", () => {
+    expect(() => {
+      parseIncludedFiles(["targetr=|'\""], windowsRootDir)
+    }).to.throw();
+  });
+
+  it("should reject pairs with absolute target path", () => {
+    expect(() => {
+      parseIncludedFiles(["/tmp/target=source"], windowsRootDir)
+    }).to.throw();
+  });
+
+  it("should accept single relative path or absolute path under root dir", () => {
+    let rawIncludedFiles = [ "myRelativeData", "/home/user/workspace/myAbsoluteData" ];
+    let parsedIncludedFiles = normalizeFileDescriptions(parseIncludedFiles(rawIncludedFiles, unitRootDir));
+
+    let expected = [
+      {
+        "targetPath": "myRelativeData",
+        "sourcePath": "/home/user/workspace/myRelativeData"
+      },
+      {
+        "targetPath": "myAbsoluteData",
+        "sourcePath": "/home/user/workspace/myAbsoluteData"
+      }
+    ];
+
+    expect(parsedIncludedFiles).to.deep.equal(expected);
+  });
+
+  it("should reject single absolute dir that is not under root dir", () => {
+    expect(() => {
+      parseIncludedFiles(["/tmp/source"], unitRootDir)
+    }).to.throw();
+  });
+
+  it("should reject string that is not a path", () => {
+    expect(() => {
+      parseIncludedFiles(["|a"], windowsRootDir)
+    }).to.throw();
   });
 });


### PR DESCRIPTION
In the current version, values of the `--include` argument had to use format `targetPath=sourcePath`.
This change allows to use only single path, as long as it is inside "root directory", i.e.:
- `--build-dir` for Xamarin UI Tests, Espresso and Appium
- `--project-dir` for Calabash

This change also improves validation and unit tests for included files parser.