### PR TITLE
Test Cloud: making manifest name consistent for all frameworks

### DIFF
--- a/src/commands/test/lib/appium-preparer.ts
+++ b/src/commands/test/lib/appium-preparer.ts
@@ -25,7 +25,7 @@ export class AppiumPreparer {
     await this.validateBuildDir();
     await pfs.cpDir(this.buildDir, this.artifactsDir);
 
-    let manifestPath = path.join(this.artifactsDir, "test-manifest.json");
+    let manifestPath = path.join(this.artifactsDir, "manifest.json");
     let manifest = await this.createAppiumManifest();
     let manifestJson = JSON.stringify(manifest, null, 1);
     await pfs.writeFile(manifestPath, manifestJson);

--- a/src/commands/test/lib/espresso-preparer.ts
+++ b/src/commands/test/lib/espresso-preparer.ts
@@ -46,7 +46,7 @@ export class EspressoPreparer {
       await this.validateBuildDir();
       await pfs.cpDir(this.buildDir, this.artifactsDir);
     }
-    let manifestPath = path.join(this.artifactsDir, "test-manifest.json");
+    let manifestPath = path.join(this.artifactsDir, "manifest.json");
     let manifest = await this.createEspressoManifest();
     let manifestJson = JSON.stringify(manifest, null, 1);
     await pfs.writeFile(manifestPath, manifestJson);

--- a/test/commands/test/lib/appium-preparer-test.ts
+++ b/test/commands/test/lib/appium-preparer-test.ts
@@ -82,6 +82,6 @@ describe("Preparing Appium workspace", () => {
     let preparer = new AppiumPreparer(artifactsDir, buildDir);
     let manifestPath = await preparer.prepare();
 
-    expect(manifestPath).to.eql(path.join(artifactsDir, "test-manifest.json"));
+    expect(manifestPath).to.eql(path.join(artifactsDir, "manifest.json"));
   });
 });


### PR DESCRIPTION
Very simple change.

Currently manifest file names for different frameworks are inconsistent. Calabash and UI Tests use `manifest.json`, and Espresso and Appium use `test-manifest.json`.

This change fixes that and uses `manifest.json` everywhere. This is important for build tasks, which will need predictable names.