### PR TITLE
Test Cloud: better commands and arguments help messages

### DIFF
--- a/src/commands/test/category.txt
+++ b/src/commands/test/category.txt
@@ -1,1 +1,1 @@
-Commands for managing tests from Mobile Center Test service
+Command for preparing, starting and checking state of Visual Studio Mobile Center tests.

--- a/src/commands/test/check-state.ts
+++ b/src/commands/test/check-state.ts
@@ -3,8 +3,9 @@ import { AppCommand, CommandArgs, CommandResult,
          failure } from "../../util/commandLine";
 import { StateChecker } from "./lib/state-checker";
 import { MobileCenterClient } from "../../util/apis";
+import { Messages } from "./lib/help-messages";
 
-@help("Checks state of test run submitted to Visual Studio Mobile Center")
+@help(Messages.TestCloud.Commands.CheckState)
 export default class CheckStateCommand extends AppCommand {
   @help("Id of the test run")
   @longName("test-run-id")

--- a/src/commands/test/check-state.ts
+++ b/src/commands/test/check-state.ts
@@ -1,5 +1,5 @@
 import { AppCommand, CommandArgs, CommandResult,
-         help, success, name, longName, required, hasArg,
+         help, success, name, longName, shortName, required, hasArg,
          failure } from "../../util/commandLine";
 import { StateChecker } from "./lib/state-checker";
 import { MobileCenterClient } from "../../util/apis";
@@ -7,14 +7,15 @@ import { Messages } from "./lib/help-messages";
 
 @help(Messages.TestCloud.Commands.CheckState)
 export default class CheckStateCommand extends AppCommand {
-  @help("Id of the test run")
+  @help(Messages.TestCloud.Arguments.CheckStateTestRunId)
   @longName("test-run-id")
   @required
   @hasArg
   testRunId: string;
 
-  @help("Continuously checks the state until the test run completes")
+  @help(Messages.TestCloud.Arguments.CheckStateContinuous)
   @longName("continuous")
+  @shortName("c")
   continuous: boolean;
 
   constructor(args: CommandArgs) {

--- a/src/commands/test/lib/help-messages.ts
+++ b/src/commands/test/lib/help-messages.ts
@@ -1,0 +1,32 @@
+import * as os from "os";
+
+export module Messages {
+  export module TestCloud {
+    export module Commands {
+      export const PrepareAppium = "Creates artifacts directory with Appium tests.";
+      export const PrepareCalabash = `Creates artifacts directory with Calabash tests.${os.EOL}` + 
+                                     `Required external tools:${os.EOL}` + 
+                                     `- Ruby ${os.EOL}` + 
+                                     `- Gem xamarin-test-cloud`;
+      export const PrepareEspresso = "Creates artifacts directory with Espresso tests.";
+      export const PrepareUITests = `Creates artifacts directory with Xamarin UI Tests.${os.EOL}` +
+                                    `Required external tools:${os.EOL}` + 
+                                    `- .NET Framework on Windows, Mono Runtime on OS X${os.EOL}` + 
+                                    `- NuGet package Xamarin.UITests, version 2.0.1 or higher`;
+
+      export const RunAppium = "Starts test run with Appium tests.";
+      export const RunCalabash = `Starts test run with Calabash tests.${os.EOL}` + 
+                                 `Required external tools:${os.EOL}` + 
+                                 `- Ruby ${os.EOL}` + 
+                                 `- Gem xamarin-test-cloud`;
+      export const RunEspresso = "Starts test run with Espresso tests.";
+      export const RunManifest = "Starts test run with previously prepared artifacts.";
+      export const RunUITests = `Starts test run with Xamarin UI Tests.${os.EOL}` + 
+                                `Required external tools:${os.EOL}` + 
+                                `- .NET Framework on Windows, Mono Runtime on OS X${os.EOL}` + 
+                                `- NuGet package Xamarin.UITests, version 2.0.1 or higher`;
+
+      export const CheckState = "Checks status of started test run.";
+    }
+  }
+}

--- a/src/commands/test/lib/help-messages.ts
+++ b/src/commands/test/lib/help-messages.ts
@@ -28,5 +28,40 @@ export module Messages {
 
       export const CheckState = "Checks status of started test run.";
     }
+
+    export module Arguments {
+      export const Include = 'Additional files and directories to include. The value must be either path relative to the input directory, or be in format "targetDir=sourceDir"';
+      export const TestParameter = 'Additional test parameters. The value must be in format "key=value"';
+      export const AppPath = "Path to an application file";
+
+      export const PrepareArtifactsDir = "Path to artifacts directory to create";
+      export const RunDevices = "Device selection slug";
+      export const RunDSymDir = "Path to directory with iOS symbol files";
+      export const RunLocale = "Locale (OS language) of the test run. For example, en-US";
+      export const RunTestSeries = "Name of the test series";
+      export const RunAsync = "Exit the command when tests are uploaded, without waiting for test results";
+
+      export const AppiumBuildDir = "Path to directory with Appium tests (usually <project>/target/upload)";
+      
+      export const CalabashProjectDir = 'Path to Calabash workspace directory (usually <project>/features)';
+      export const CalabashSignInfo = "Use Signing Info for signing the test server";
+      export const CalabashConfigPath = "Path to Cucumber configuration file (usually cucumber.yml)";
+      export const CalabashProfile = "Profile to run. It must exist in the configuration file";
+      export const CalabashSkipConfigCheck = "Force running without Cucumber profile";
+      
+      export const EspressoBuildDir = "Path to Espresso output directory (usually <project>/build/outputs/apk)";
+      export const EspressoTestApkPath = "Path to *.apk file with Espresso tests. If not set, build-dir is used to discover it";
+
+      export const UITestsBuildDir = "Path to directory with built test assemblies (usually <project>/bin/<configuration>)";
+      export const UITestsStoreFile = "TODO";
+      export const UITestsStorePassword = "TODO";
+      export const UITestsKeyAlias = "TODO";
+      export const UITestsKeyPassword = "TODO";
+      export const UITestsSignInfo = "Use Signing Info for signing the test server.";
+      export const UITestsToolsDir = "Path to directory with Xamarin UI Tests tools that contains test-cloud.exe";
+
+      export const CheckStateTestRunId = "ID of started test run";
+      export const CheckStateContinuous = "Continuously checks test run status until it completes";
+    }
   }
 }

--- a/src/commands/test/lib/prepare-tests-command.ts
+++ b/src/commands/test/lib/prepare-tests-command.ts
@@ -6,23 +6,24 @@ import { parseTestParameters } from "./parameters-parser";
 import { parseIncludedFiles } from "./included-files-parser";
 import { progressWithResult } from "./interaction";
 import { ITestCloudManifestJson, ITestFrameworkJson, IFileDescriptionJson } from "./test-manifest-reader";
+import { Messages } from "./help-messages";
 import * as _ from "lodash";
 import * as path from "path";
 import * as pfs from "../../../util/misc/promisfied-fs";
 
 export class PrepareTestsCommand extends Command {
   
-  @help("Path to output directory where all test files will be copied")
+  @help(Messages.TestCloud.Arguments.PrepareArtifactsDir)
   @longName("artifacts-dir")
   @hasArg
   artifactsDir: string;
 
-  @help("Additional files / directories that should be included in the test run. The value should be in format 'sourceDir=targetDir'")
+  @help(Messages.TestCloud.Arguments.Include)
   @longName("include")
   @hasArg
   include: string[];
 
-  @help("Additional test parameters that should be included in the test run. The value should be in format key=value")
+  @help(Messages.TestCloud.Arguments.TestParameter)
   @longName("test-parameter")
   @shortName("p")
   @hasArg

--- a/src/commands/test/lib/run-tests-command.ts
+++ b/src/commands/test/lib/run-tests-command.ts
@@ -10,50 +10,51 @@ import { parseTestParameters } from "./parameters-parser";
 import { parseIncludedFiles } from "./included-files-parser";
 import { progressWithResult } from "./interaction";
 import { ITestCloudManifestJson, ITestFrameworkJson, IFileDescriptionJson } from "./test-manifest-reader";
+import { Messages } from "./help-messages";
 import * as _ from "lodash";
 import * as pfs from "../../../util/misc/promisfied-fs";
 import * as path from "path";
 import * as temp from "temp";
 
 export class RunTestsCommand extends AppCommand {
-  @help("Path to an application file")
+  @help(Messages.TestCloud.Arguments.AppPath)
   @longName("app-path")
   @hasArg
   appPath: string;
 
-  @help("Selected devices slug")
+  @help(Messages.TestCloud.Arguments.RunDevices)
   @longName("devices")
   @hasArg
   @required
   devices: string;
 
-  @help("Path to dSym directory")
+  @help(Messages.TestCloud.Arguments.RunDSymDir)
   @longName("dsym-dir")
   @hasArg
   dSymDir: string;
 
-  @help("Locale for the test run (e.g. en-US)")
+  @help(Messages.TestCloud.Arguments.RunLocale)
   @longName("locale")
   @hasArg
   locale: string;
 
-  @help("Test series name")
+  @help(Messages.TestCloud.Arguments.RunTestSeries)
   @longName("test-series")
   @hasArg
   testSeries: string;
 
-  @help("Additional files / directories that should be included in the test run. The value should be in format 'sourceDir=targetDir'")
+  @help(Messages.TestCloud.Arguments.Include)
   @longName("include")
   @hasArg
   include: string[];
 
-  @help("Additional test parameters that should be included in the test run. The value should be in format key=value")
+  @help(Messages.TestCloud.Arguments.TestParameter)
   @longName("test-parameter")
   @shortName("p")
   @hasArg
   testParameters: string[];
 
-  @help("Don't block waiting for test results")
+  @help(Messages.TestCloud.Arguments.RunAsync)
   @longName("async")
   async: boolean;
 

--- a/src/commands/test/prepare/appium.ts
+++ b/src/commands/test/prepare/appium.ts
@@ -7,7 +7,7 @@ import { Messages } from "../lib/help-messages";
 
 @help(Messages.TestCloud.Commands.PrepareAppium)
 export default class PrepareAppiumCommand extends PrepareTestsCommand {
-  @help("Path to Appium output directory (usually target/upload)")
+  @help(Messages.TestCloud.Arguments.AppiumBuildDir)
   @longName("build-dir")
   @hasArg
   @required

--- a/src/commands/test/prepare/appium.ts
+++ b/src/commands/test/prepare/appium.ts
@@ -3,8 +3,9 @@ import { CommandArgs, help, success, name, longName, required, hasArg,
 import { AppiumPreparer } from "../lib/appium-preparer";
 import { PrepareTestsCommand } from "../lib/prepare-tests-command";
 import { out } from "../../../util/interaction";
+import { Messages } from "../lib/help-messages";
 
-@help("Prepares Appium artifacts for test run")
+@help(Messages.TestCloud.Commands.PrepareAppium)
 export default class PrepareAppiumCommand extends PrepareTestsCommand {
   @help("Path to Appium output directory (usually target/upload)")
   @longName("build-dir")

--- a/src/commands/test/prepare/calabash.ts
+++ b/src/commands/test/prepare/calabash.ts
@@ -11,34 +11,34 @@ const debug = require("debug")("mobile-center-cli:commands:test:prepare:calabash
 
 @help(Messages.TestCloud.Commands.PrepareCalabash)
 export default class PrepareCalabashCommand extends PrepareTestsCommand {
-  @help("Path to an application file")
+  @help(Messages.TestCloud.Arguments.AppPath)
   @longName("app-path")
   @required
   @hasArg
   appPath: string;
 
-  @help("Path to workspace")
+  @help(Messages.TestCloud.Arguments.CalabashProjectDir)
   @longName("project-dir")
   @required
   @hasArg
   projectDir: string;
 
-  @help("Use Signing Info for signing the test server")
+  @help(Messages.TestCloud.Arguments.CalabashSignInfo)
   @longName("sign-info")
   @hasArg
   signInfo: string;
 
-  @help("Path to Cucumber configuration. Can be relative to workspace")
+  @help(Messages.TestCloud.Arguments.CalabashConfigPath)
   @longName("config")
   @hasArg
   config: string;
 
-  @help("TODO")
+  @help(Messages.TestCloud.Arguments.CalabashProfile)
   @longName("profile")
   @hasArg
   profile: string;
 
-  @help("TODO")
+  @help(Messages.TestCloud.Arguments.CalabashSkipConfigCheck)
   @longName("skip-config-check")
   skipConfigCheck: boolean;
 

--- a/src/commands/test/prepare/calabash.ts
+++ b/src/commands/test/prepare/calabash.ts
@@ -5,10 +5,11 @@ import { PrepareTestsCommand } from "../lib/prepare-tests-command";
 import { out } from "../../../util/interaction";
 import * as outExtensions from "../lib/interaction";
 import * as process from "../../../util/misc/process-helper";
+import { Messages } from "../lib/help-messages";
 
 const debug = require("debug")("mobile-center-cli:commands:test:prepare:calabash");
 
-@help("Prepares Calabash artifacts for test run")
+@help(Messages.TestCloud.Commands.PrepareCalabash)
 export default class PrepareCalabashCommand extends PrepareTestsCommand {
   @help("Path to an application file")
   @longName("app-path")

--- a/src/commands/test/prepare/category.txt
+++ b/src/commands/test/prepare/category.txt
@@ -1,1 +1,5 @@
-Commands that prepare tests for run in the Mobile Center Test Cloud. 
+Commands that creates artifacts directories for supported test frameworks.
+
+Depending on the test framework, you may need to install additional tools. For example, Xamarin UI Tests require either .NET Framework or Mono, and Calabash tests require Ruby and the Xamarin Test Cloud gem. To get more information about dependencies of selected test framework, please type "mobile-center help test prepare [framework name]".
+
+Artifacts directory contains manifest and all files required to start a test run. It can be later submitted to Test Cloud, without any external, framework-specific tools.

--- a/src/commands/test/prepare/espresso.ts
+++ b/src/commands/test/prepare/espresso.ts
@@ -3,8 +3,9 @@ import { CommandArgs, help, success, name, shortName, longName, required, hasArg
 import { EspressoPreparer } from "../lib/espresso-preparer";
 import { PrepareTestsCommand } from "../lib/prepare-tests-command";
 import { out } from "../../../util/interaction";
+import { Messages } from "../lib/help-messages";
 
-@help("Prepares Espresso artifacts for test run")
+@help(Messages.TestCloud.Commands.PrepareEspresso)
 export default class PrepareEspressoCommand extends PrepareTestsCommand {
   @help("Path to Espresso output directory (usually <project>/build/outputs/apk)")
   @longName("build-dir")

--- a/src/commands/test/prepare/espresso.ts
+++ b/src/commands/test/prepare/espresso.ts
@@ -7,12 +7,12 @@ import { Messages } from "../lib/help-messages";
 
 @help(Messages.TestCloud.Commands.PrepareEspresso)
 export default class PrepareEspressoCommand extends PrepareTestsCommand {
-  @help("Path to Espresso output directory (usually <project>/build/outputs/apk)")
+  @help(Messages.TestCloud.Arguments.EspressoBuildDir)
   @longName("build-dir")
   @hasArg
   buildDir: string;
 
-  @help("Path to Espresso tests .apk file (default uses build-dir to detect this file)")
+  @help(Messages.TestCloud.Arguments.EspressoTestApkPath)
   @longName("test-apk-path")
   @hasArg
   testApkPath: string;

--- a/src/commands/test/prepare/uitest.ts
+++ b/src/commands/test/prepare/uitest.ts
@@ -5,10 +5,11 @@ import { PrepareTestsCommand } from "../lib/prepare-tests-command";
 import { out } from "../../../util/interaction";
 import * as outExtensions from "../lib/interaction";
 import * as process from "../../../util/misc/process-helper";
+import { Messages } from "../lib/help-messages";
 
 const debug = require("debug")("mobile-center-cli:commands:tests:prepare");
 
-@help("Prepares UI Test artifacts for test run")
+@help(Messages.TestCloud.Commands.PrepareUITests)
 export default class PrepareUITestCommand extends PrepareTestsCommand {
   @help("Path to an application file")
   @longName("app-path")

--- a/src/commands/test/prepare/uitest.ts
+++ b/src/commands/test/prepare/uitest.ts
@@ -11,44 +11,44 @@ const debug = require("debug")("mobile-center-cli:commands:tests:prepare");
 
 @help(Messages.TestCloud.Commands.PrepareUITests)
 export default class PrepareUITestCommand extends PrepareTestsCommand {
-  @help("Path to an application file")
+  @help(Messages.TestCloud.Arguments.AppPath)
   @longName("app-path")
   @required
   @hasArg
   appPath: string;
 
-  @help("Path to directory with test assemblies")
+  @help(Messages.TestCloud.Arguments.UITestsBuildDir)
   @longName("build-dir")
   @required
   @hasArg
   buildDir: string;
 
-  @help("TODO")
+  @help(Messages.TestCloud.Arguments.UITestsStoreFile)
   @longName("store-file")
   @hasArg
   storeFile: string;
 
-  @help("TODO")
+  @help(Messages.TestCloud.Arguments.UITestsStorePassword)
   @longName("store-password")
   @hasArg
   storePassword: string;
 
-  @help("TODO")
+  @help(Messages.TestCloud.Arguments.UITestsKeyAlias)
   @longName("key-alias")
   @hasArg
   keyAlias: string;
 
-  @help("TODO")
+  @help(Messages.TestCloud.Arguments.UITestsKeyPassword)
   @longName("key-password")
   @hasArg
   keyPassword: string;
 
-  @help("Use Signing Info for signing the test server")
+  @help(Messages.TestCloud.Arguments.UITestsSignInfo)
   @longName("sign-info")
   @hasArg
   signInfo: string;
 
-  @help("Path to Xamarin UITest tools directory that contains test-cloud.exe")
+  @help(Messages.TestCloud.Arguments.UITestsToolsDir)
   @longName("uitest-tools-dir")
   @hasArg
   uiTestToolsDir: string;

--- a/src/commands/test/run/appium.ts
+++ b/src/commands/test/run/appium.ts
@@ -7,7 +7,7 @@ import { Messages } from "../lib/help-messages";
 
 @help(Messages.TestCloud.Commands.RunAppium)
 export default class RunAppiumTestsCommand extends RunTestsCommand {
-  @help("Path to Appium output directory (usually target/upload)")
+  @help(Messages.TestCloud.Arguments.AppiumBuildDir)
   @longName("build-dir")
   @hasArg
   buildDir: string;

--- a/src/commands/test/run/appium.ts
+++ b/src/commands/test/run/appium.ts
@@ -3,8 +3,9 @@ import { RunTestsCommand } from "../lib/run-tests-command";
 import { AppiumPreparer } from "../lib/appium-preparer";
 import { parseTestParameters } from "../lib/parameters-parser";
 import { parseIncludedFiles } from "../lib/included-files-parser";
+import { Messages } from "../lib/help-messages";
 
-@help("Prepares and runs Appium tests")
+@help(Messages.TestCloud.Commands.RunAppium)
 export default class RunAppiumTestsCommand extends RunTestsCommand {
   @help("Path to Appium output directory (usually target/upload)")
   @longName("build-dir")

--- a/src/commands/test/run/calabash.ts
+++ b/src/commands/test/run/calabash.ts
@@ -3,8 +3,9 @@ import { RunTestsCommand } from "../lib/run-tests-command";
 import { CalabashPreparer } from "../lib/calabash-preparer";
 import { parseTestParameters } from "../lib/parameters-parser";
 import { parseIncludedFiles } from "../lib/included-files-parser";
+import { Messages } from "../lib/help-messages";
 
-@help("Prepares and runs Calabash tests")
+@help(Messages.TestCloud.Commands.RunCalabash)
 export default class RunCalabashTestsCommand extends RunTestsCommand {
   @help("Path to workspace")
   @longName("workspace")

--- a/src/commands/test/run/calabash.ts
+++ b/src/commands/test/run/calabash.ts
@@ -7,28 +7,28 @@ import { Messages } from "../lib/help-messages";
 
 @help(Messages.TestCloud.Commands.RunCalabash)
 export default class RunCalabashTestsCommand extends RunTestsCommand {
-  @help("Path to workspace")
-  @longName("workspace")
+  @help(Messages.TestCloud.Arguments.CalabashProjectDir)
+  @longName("project-dir")
   @required
   @hasArg
   projectDir: string;
 
-  @help("Use Signing Info for signing the test server")
+  @help(Messages.TestCloud.Arguments.CalabashSignInfo)
   @longName("sign-info")
   @hasArg
   signInfo: string;
 
-  @help("Path to Cucumber configuration. Can be relative to workspace")
-  @longName("config")
+  @help(Messages.TestCloud.Arguments.CalabashConfigPath)
+  @longName("config-path")
   @hasArg
   config: string;
 
-  @help("TODO")
+  @help(Messages.TestCloud.Arguments.CalabashProfile)
   @longName("profile")
   @hasArg
   profile: string;
 
-  @help("TODO")
+  @help(Messages.TestCloud.Arguments.CalabashSkipConfigCheck)
   @longName("skip-config-check")
   skipConfigCheck: boolean;
 

--- a/src/commands/test/run/category.txt
+++ b/src/commands/test/run/category.txt
@@ -1,1 +1,7 @@
-Commands that upload and start test runs in the Mobile Center Test Cloud. 
+Commands that upload and start test runs.
+
+These commands can automatically create artifacts directory for supported test frameworks, or upload previously prepared artifacts.
+
+The former approach - automatically creating artifacts directory - is simpler to use, but may require additional tools. For example, Xamarin UI Tests require either .NET Framework or Mono, and Calabash tests require Ruby and the Xamarin Test Cloud gem.
+
+The latter approach - uploading previously prepared artifacts directory - does not require any other tools. It can be used in CI systems where tests are built and started from different machines.

--- a/src/commands/test/run/espresso.ts
+++ b/src/commands/test/run/espresso.ts
@@ -8,18 +8,18 @@ import { Messages } from "../lib/help-messages";
 @help(Messages.TestCloud.Commands.RunEspresso)
 export default class RunEspressoTestsCommand extends RunTestsCommand {
 
-  @help("Path to an application file")
+  @help(Messages.TestCloud.Arguments.AppPath)
   @longName("app-path")
   @required
   @hasArg
   appPath: string;
 
-  @help("Path to Espresso build directory (usually <project>/build/outputs/apk)")
+  @help(Messages.TestCloud.Arguments.EspressoBuildDir)
   @longName("build-dir")
   @hasArg
   buildDir: string;
 
-  @help("Path to Espresso tests .apk file (default uses build-dir to detect this file)")
+  @help(Messages.TestCloud.Arguments.EspressoTestApkPath)
   @longName("test-apk-path")
   @hasArg
   testApkPath: string;

--- a/src/commands/test/run/espresso.ts
+++ b/src/commands/test/run/espresso.ts
@@ -3,8 +3,9 @@ import { RunTestsCommand } from "../lib/run-tests-command";
 import { EspressoPreparer } from "../lib/espresso-preparer";
 import { parseTestParameters } from "../lib/parameters-parser";
 import { parseIncludedFiles } from "../lib/included-files-parser";
+import { Messages } from "../lib/help-messages";
 
-@help("Prepares and runs Espresso tests")
+@help(Messages.TestCloud.Commands.RunEspresso)
 export default class RunEspressoTestsCommand extends RunTestsCommand {
 
   @help("Path to an application file")

--- a/src/commands/test/run/manifest.ts
+++ b/src/commands/test/run/manifest.ts
@@ -1,8 +1,9 @@
 import { CommandArgs, help, name, longName, required, hasArg } from "../../../util/commandLine";
 import { RunTestsCommand } from "../lib/run-tests-command";
+import { Messages } from "../lib/help-messages";
 import * as path from "path";
 
-@help("Submits tests described by a manifest to Mobile Center Test Cloud")
+@help(Messages.TestCloud.Commands.RunManifest)
 export default class RunManifestTestsCommand extends RunTestsCommand {
   @help("Path to manifest file")
   @longName("manifest-path")

--- a/src/commands/test/run/uitest.ts
+++ b/src/commands/test/run/uitest.ts
@@ -7,44 +7,44 @@ import { Messages } from "../lib/help-messages";
 
 @help(Messages.TestCloud.Commands.RunUITests)
 export default class RunUITestsCommand extends RunTestsCommand {
-  @help("Path to an application file")
+  @help(Messages.TestCloud.Arguments.AppPath)
   @longName("app-path")
   @required
   @hasArg
   appPath: string;
 
-  @help("Path to directory with test assemblies")
+  @help(Messages.TestCloud.Arguments.UITestsBuildDir)
   @longName("build-dir")
   @required
   @hasArg
   buildDir: string;
 
-  @help("TODO")
+  @help(Messages.TestCloud.Arguments.UITestsStoreFile)
   @longName("store-file")
   @hasArg
   storeFile: string;
 
-  @help("TODO")
+  @help(Messages.TestCloud.Arguments.UITestsStorePassword)
   @longName("store-password")
   @hasArg
   storePassword: string;
 
-  @help("TODO")
+  @help(Messages.TestCloud.Arguments.UITestsKeyAlias)
   @longName("key-alias")
   @hasArg
   keyAlias: string;
 
-  @help("TODO")
+  @help(Messages.TestCloud.Arguments.UITestsKeyPassword)
   @longName("key-password")
   @hasArg
   keyPassword: string;
 
-  @help("Use Signing Info for signing the test server")
+  @help(Messages.TestCloud.Arguments.UITestsSignInfo)
   @longName("sign-info")
   @hasArg
   signInfo: string;
 
-  @help("Path to Xamarin UITest tools directory that contains test-cloud.exe")
+  @help(Messages.TestCloud.Arguments.UITestsToolsDir)
   @longName("uitest-tools-dir")
   @hasArg
   uiTestToolsDir: string;

--- a/src/commands/test/run/uitest.ts
+++ b/src/commands/test/run/uitest.ts
@@ -3,8 +3,9 @@ import { RunTestsCommand } from "../lib/run-tests-command";
 import { UITestPreparer } from "../lib/uitest-preparer";
 import { parseTestParameters } from "../lib/parameters-parser";
 import { parseIncludedFiles } from "../lib/included-files-parser";
+import { Messages } from "../lib/help-messages";
 
-@help("Prepares and runs UI tests")
+@help(Messages.TestCloud.Commands.RunUITests)
 export default class RunUITestsCommand extends RunTestsCommand {
   @help("Path to an application file")
   @longName("app-path")


### PR DESCRIPTION
The biggest change in this PR is introducing new module "help-messages", which stores messages for all Test Cloud commands and arguments. This fixes two problems:
1. Some commands shared arguments names, but used separate help strings which could easy get out of sync.
2. It was very difficult to review help messages, which were scattered around the entire project.
