### PR TITLE
Test Cloud: adding back --workspace parameter to ensure backwards compatibility

### DIFF
--- a/src/commands/test/prepare/calabash.ts
+++ b/src/commands/test/prepare/calabash.ts
@@ -19,9 +19,13 @@ export default class PrepareCalabashCommand extends PrepareTestsCommand {
 
   @help(Messages.TestCloud.Arguments.CalabashProjectDir)
   @longName("project-dir")
-  @required
   @hasArg
   projectDir: string;
+
+  @help("Obsolete. Please use --project-dir instead")
+  @longName("workspace")
+  @hasArg
+  workspaceDir: string;
 
   @help(Messages.TestCloud.Arguments.CalabashSignInfo)
   @longName("sign-info")
@@ -44,6 +48,15 @@ export default class PrepareCalabashCommand extends PrepareTestsCommand {
 
   constructor(args: CommandArgs) {
     super(args);
+
+    if (this.workspaceDir && !this.projectDir) {
+      out.text("Argument --workspace is obsolete. Please use --project-dir instead");
+      this.projectDir = this.workspaceDir;
+    }
+
+    if (!this.projectDir) {
+      throw new Error("Argument --project-dir is required");
+    }
   }
 
   protected prepareManifest(): Promise<string> {

--- a/src/commands/test/prepare/uitest.ts
+++ b/src/commands/test/prepare/uitest.ts
@@ -19,9 +19,13 @@ export default class PrepareUITestCommand extends PrepareTestsCommand {
 
   @help(Messages.TestCloud.Arguments.UITestsBuildDir)
   @longName("build-dir")
-  @required
   @hasArg
   buildDir: string;
+
+  @help("Obsolete. Please use --build-dir instead")
+  @longName("assembly-dir")
+  @hasArg
+  assemblyDir: string;
 
   @help(Messages.TestCloud.Arguments.UITestsStoreFilePath)
   @longName("store-path")
@@ -55,6 +59,15 @@ export default class PrepareUITestCommand extends PrepareTestsCommand {
 
   constructor(args: CommandArgs) {
     super(args);
+
+    if (this.assemblyDir && !this.buildDir) {
+      out.text("Argument --assembly-dir is obsolete. Please use --build-dir instead.")
+      this.buildDir = this.assemblyDir;
+    }
+
+    if (!this.buildDir) {
+      throw new Error("Argument --build-dir is required");
+    }
   }
 
   protected prepareManifest(): Promise<string> {

--- a/src/commands/test/run/calabash.ts
+++ b/src/commands/test/run/calabash.ts
@@ -4,6 +4,7 @@ import { CalabashPreparer } from "../lib/calabash-preparer";
 import { parseTestParameters } from "../lib/parameters-parser";
 import { parseIncludedFiles } from "../lib/included-files-parser";
 import { Messages } from "../lib/help-messages";
+import { out } from "../../../util/interaction";
 
 @help(Messages.TestCloud.Commands.RunCalabash)
 export default class RunCalabashTestsCommand extends RunTestsCommand {
@@ -12,6 +13,11 @@ export default class RunCalabashTestsCommand extends RunTestsCommand {
   @required
   @hasArg
   projectDir: string;
+
+  @help("Obsolete. Please use --project-dir instead")
+  @longName("workspace")
+  @hasArg
+  workspaceDir: string;
 
   @help(Messages.TestCloud.Arguments.CalabashSignInfo)
   @longName("sign-info")
@@ -34,6 +40,15 @@ export default class RunCalabashTestsCommand extends RunTestsCommand {
 
   constructor(args: CommandArgs) {
     super(args);
+
+    if (this.workspaceDir && !this.projectDir) {
+      out.text("Argument --workspace is obsolete. Please use --project-dir instead.");
+      this.projectDir = this.workspaceDir;
+    }
+
+    if (!this.projectDir) {
+      throw new Error("Argument --project-dir is required");
+    }
   }
 
   protected prepareManifest(artifactsDir: string): Promise<string> {

--- a/src/commands/test/run/uitest.ts
+++ b/src/commands/test/run/uitest.ts
@@ -4,6 +4,7 @@ import { UITestPreparer } from "../lib/uitest-preparer";
 import { parseTestParameters } from "../lib/parameters-parser";
 import { parseIncludedFiles } from "../lib/included-files-parser";
 import { Messages } from "../lib/help-messages";
+import { out } from "../../../util/interaction";
 
 @help(Messages.TestCloud.Commands.RunUITests)
 export default class RunUITestsCommand extends RunTestsCommand {
@@ -15,9 +16,13 @@ export default class RunUITestsCommand extends RunTestsCommand {
 
   @help(Messages.TestCloud.Arguments.UITestsBuildDir)
   @longName("build-dir")
-  @required
   @hasArg
   buildDir: string;
+
+  @help("Obsolete. Please use --build-dir instead")
+  @longName("assembly-dir")
+  @hasArg
+  assemblyDir: string;
 
   @help(Messages.TestCloud.Arguments.UITestsStoreFilePath)
   @longName("store-path")
@@ -51,6 +56,15 @@ export default class RunUITestsCommand extends RunTestsCommand {
 
   constructor(args: CommandArgs) {
     super(args);
+
+    if (this.assemblyDir && !this.buildDir) {
+      out.text("Argument --assembly-dir is obsolete. Please use --build-dir instead.")
+      this.buildDir = this.assemblyDir;
+    }
+
+    if (!this.buildDir) {
+      throw new Error("Argument --build-dir is required");
+    }
   }
 
   protected prepareManifest(artifactsDir: string): Promise<string> {


### PR DESCRIPTION
Last change before we are ready for VSTS tasks integration.

One of the previous changes replaced "--workspace" parameter for Calabash commands with "--project-dir". The new name follows the naming convention used elsewhere in the CLI.

However, the Test Beacon UI generates CLI command for submitting tests, and it still uses "--workspace". We cannot expect that the CLI and UI will be released at the same time (and that all users will immediately upgrade the CLI), so we want to keep the old parameter (along with the new one) for some time. The entire update will go as follows:
1. We will release the new CLI which accepts both --workspace and --project-dir
2. A week after that we will update instructions in our UI.
3. After a month or two, with a new CLI release, we will remove --workspace from the CLI.

[Edited]
The same happens to --assembly-dir parameter for Xamarin UI Tests - it got renamed to --build-dir. This PR adds it back to ensure compatibility.
