### PR TITLE
Default explanation text for `mobile-center test` is poorly formatted

### DIFF
--- a/src/util/interaction/out.ts
+++ b/src/util/interaction/out.ts
@@ -10,6 +10,8 @@ import * as wrap from "wordwrap";
 const Table = require("cli-table2");
 const Spinner = require("cli-spinner").Spinner;
 
+import { terminal } from "./terminal";
+
 //
 // Display a progress spinner while waiting for the provided promise
 // to complete.
@@ -113,17 +115,26 @@ export function table(...args: any[]): void {
 }
 
 //
-// Formatting helper for cli-table2 - no table outlines. Used by
+// Formatting helper for cli-table2 - two columns with no table outlines. Used by
 // help commands for formatting lists of options, commands, etc.
 //
-export const noTableBorders = {
-  chars: {
-    "top": "", "top-mid": "", "top-left": "", "top-right": "",
-    "bottom": "", "bottom-mid": "", "bottom-left": "", "bottom-right": "",
-    "left": "", "left-mid": "", "mid": "", "mid-mid": "",
-    "right": "", "right-mid": "", "middle": " "
-  },
-  style: { "padding-left": 0, "padding-right": 0 }
+export function getOptionsForTwoColumnTableWithNoBorders(firstColumnWidth: number) {
+  const consoleWidth = terminal.columns();
+  // There will be a single whitespace to the right from the each column, count it as unavailable
+  const availableWidth = consoleWidth - 2;
+  const secondColumnWidth = availableWidth - firstColumnWidth;
+
+  return {
+    chars: {
+      "top": "", "top-mid": "", "top-left": "", "top-right": "",
+      "bottom": "", "bottom-mid": "", "bottom-left": "", "bottom-right": "",
+      "left": "", "left-mid": "", "mid": " ", "mid-mid": "",
+      "right": "", "right-mid": "", "middle": " "
+    },
+    style: { "padding-left": 0, "padding-right": 0 },
+    colWidths: [firstColumnWidth, secondColumnWidth],
+    wordWrap: true
+  }
 };
 
 //


### PR DESCRIPTION
Fix for #93 

1. Fixed the explanation text formatting by setting the `colWidths` on the `noTableBorders` settings set. `colWidths` are calculated from the current console width.

2. Fixed another problem which also broke output formatting in some consoles (e.g. cmder and powershell). It was caused by the presence of the CRLF characters in some of the category.txt files. cli-table2 doesn't take CR into account (i.e. doesn't removes it when wrapping strings to fit into table cell), thus breaking the formatting.

Here is how it looks like after the fix (powershell console as an example):

![powershell](https://cloud.githubusercontent.com/assets/25530829/22602833/f0b61c6e-ea55-11e6-8685-98bb292f7791.PNG)

Please, note that there is no space between rightmost top cell and the one below it (see the red line on the next image):

![powershell_redline](https://cloud.githubusercontent.com/assets/25530829/22603303/e2119f06-ea57-11e6-9312-9c0b8c5ce1ae.png)

Is it by design? Or should I add a horizontal space between them?

