### PR TITLE
Fixes for `test generate uitest`

### DIFF
--- a/src/commands/test/generate/uitest.ts
+++ b/src/commands/test/generate/uitest.ts
@@ -33,8 +33,8 @@ export default class GenerateUITestCommand extends Command {
 
     if (await pfs.exists(this.outputPath)) {
       let files = await pfs.readdir(this.outputPath);
-      if (!files.length) {
-        failure(ErrorCodes.Exception, this.outputPath + " exists and is not empty");
+      if (!(files.length === 0)) {
+        return failure(ErrorCodes.Exception, this.outputPath + " exists and is not empty");
       }
     }
 

--- a/src/commands/test/generate/uitest.ts
+++ b/src/commands/test/generate/uitest.ts
@@ -23,14 +23,14 @@ export default class GenerateUITestCommand extends Command {
 
   constructor(args: CommandArgs) {
     super(args);
-
-    if (this.platform.toLowerCase() != "ios" && this.platform.toLowerCase() != "android") {
-      throw new Error("Valid values of argument --platform are 'ios' and 'android'");
-    }
   }
 
   async run(client: MobileCenterClient): Promise<CommandResult> {
 
+    if (this.platform.toLowerCase() != "ios" && this.platform.toLowerCase() != "android") {
+      throw new Error("Valid values of argument --platform are 'ios' and 'android'");
+    }
+    
     if (await pfs.exists(this.outputPath)) {
       let files = await pfs.readdir(this.outputPath);
       if (!(files.length === 0)) {


### PR DESCRIPTION
- Perform the parameter validation in run as throwing an exception within the constructor results in no output.  This had also broken `help test generate uitest`.
- Compare `files.length` to 0 as `files.length` always evaluates to false.
- Missing return when using `failure()`

@krukow There will be a separate PR to fix the `help test prepare/run` commands