### PR TITLE
Avoid throwing errors in command constructors

### DIFF
--- a/src/commands/test/lib/prepare-tests-command.ts
+++ b/src/commands/test/lib/prepare-tests-command.ts
@@ -41,8 +41,13 @@ export class PrepareTestsCommand extends Command {
     }
   }
 
+  // Override this for things like parameter validation to avoid throwing errors in the constructor
+  protected async runNoClientInner(): Promise<void> {
+  }
+
   public async runNoClient(): Promise<CommandResult> {
     try {
+      await this.runNoClientInner();
       let manifestPath = await progressWithResult("Preparing tests", this.prepareManifest());
       await this.addIncludedFilesAndTestParametersToManifest(manifestPath);
       out.text(this.getSuccessMessage(manifestPath));

--- a/src/commands/test/lib/prepare-tests-command.ts
+++ b/src/commands/test/lib/prepare-tests-command.ts
@@ -41,13 +41,13 @@ export class PrepareTestsCommand extends Command {
     }
   }
 
-  // Override this for things like parameter validation to avoid throwing errors in the constructor
-  protected async runNoClientInner(): Promise<void> {
+  // Override this if you need to validate options
+  protected async validateOptions(): Promise<void> {
   }
 
   public async runNoClient(): Promise<CommandResult> {
     try {
-      await this.runNoClientInner();
+      await this.validateOptions();
       let manifestPath = await progressWithResult("Preparing tests", this.prepareManifest());
       await this.addIncludedFilesAndTestParametersToManifest(manifestPath);
       out.text(this.getSuccessMessage(manifestPath));

--- a/src/commands/test/lib/run-tests-command.ts
+++ b/src/commands/test/lib/run-tests-command.ts
@@ -76,12 +76,12 @@ export class RunTestsCommand extends AppCommand {
     }
   }
 
-  // Override this for things like parameter validation to avoid throwing errors in the constructor
-  protected async runInner(): Promise<void> {
+  // Override this if you need to validate options
+  protected async validateOptions(): Promise<void> {
   }
 
   public async run(client: MobileCenterClient): Promise<CommandResult> {
-    await this.runInner();
+    await this.validateOptions();
     try {
       let artifactsDir = await this.getArtifactsDir();
 

--- a/src/commands/test/lib/run-tests-command.ts
+++ b/src/commands/test/lib/run-tests-command.ts
@@ -76,7 +76,12 @@ export class RunTestsCommand extends AppCommand {
     }
   }
 
+  // Override this for things like parameter validation to avoid throwing errors in the constructor
+  protected async runInner(): Promise<void> {
+  }
+
   public async run(client: MobileCenterClient): Promise<CommandResult> {
+    await this.runInner();
     try {
       let artifactsDir = await this.getArtifactsDir();
 

--- a/src/commands/test/prepare/calabash.ts
+++ b/src/commands/test/prepare/calabash.ts
@@ -48,7 +48,9 @@ export default class PrepareCalabashCommand extends PrepareTestsCommand {
 
   constructor(args: CommandArgs) {
     super(args);
+  }
 
+  protected async runNoClientInner(): Promise<void> {
     if (this.workspaceDir && !this.projectDir) {
       out.text("Argument --workspace is obsolete. Please use --project-dir instead.");
       this.projectDir = this.workspaceDir;

--- a/src/commands/test/prepare/calabash.ts
+++ b/src/commands/test/prepare/calabash.ts
@@ -50,7 +50,7 @@ export default class PrepareCalabashCommand extends PrepareTestsCommand {
     super(args);
   }
 
-  protected async runNoClientInner(): Promise<void> {
+  protected async validateOptions(): Promise<void> {
     if (this.workspaceDir && !this.projectDir) {
       out.text("Argument --workspace is obsolete. Please use --project-dir instead.");
       this.projectDir = this.workspaceDir;

--- a/src/commands/test/prepare/uitest.ts
+++ b/src/commands/test/prepare/uitest.ts
@@ -59,7 +59,9 @@ export default class PrepareUITestCommand extends PrepareTestsCommand {
 
   constructor(args: CommandArgs) {
     super(args);
+  }
 
+  protected async runNoClientInner(): Promise<void> {
     if (this.assemblyDir && !this.buildDir) {
       out.text("Argument --assembly-dir is obsolete. Please use --build-dir instead.")
       this.buildDir = this.assemblyDir;

--- a/src/commands/test/prepare/uitest.ts
+++ b/src/commands/test/prepare/uitest.ts
@@ -61,7 +61,7 @@ export default class PrepareUITestCommand extends PrepareTestsCommand {
     super(args);
   }
 
-  protected async runNoClientInner(): Promise<void> {
+  protected async validateOptions(): Promise<void> {
     if (this.assemblyDir && !this.buildDir) {
       out.text("Argument --assembly-dir is obsolete. Please use --build-dir instead.")
       this.buildDir = this.assemblyDir;

--- a/src/commands/test/run/calabash.ts
+++ b/src/commands/test/run/calabash.ts
@@ -40,7 +40,9 @@ export default class RunCalabashTestsCommand extends RunTestsCommand {
 
   constructor(args: CommandArgs) {
     super(args);
+  }
 
+  protected async runInner(): Promise<void> {
     if (this.workspaceDir && !this.projectDir) {
       out.text("Argument --workspace is obsolete. Please use --project-dir instead.");
       this.projectDir = this.workspaceDir;

--- a/src/commands/test/run/calabash.ts
+++ b/src/commands/test/run/calabash.ts
@@ -42,7 +42,7 @@ export default class RunCalabashTestsCommand extends RunTestsCommand {
     super(args);
   }
 
-  protected async runInner(): Promise<void> {
+  protected async validateOptions(): Promise<void> {
     if (this.workspaceDir && !this.projectDir) {
       out.text("Argument --workspace is obsolete. Please use --project-dir instead.");
       this.projectDir = this.workspaceDir;

--- a/src/commands/test/run/uitest.ts
+++ b/src/commands/test/run/uitest.ts
@@ -58,7 +58,7 @@ export default class RunUITestsCommand extends RunTestsCommand {
     super(args);
   }
 
-  protected async runInner(): Promise<void> {
+  protected async validateOptions(): Promise<void> {
     if (this.assemblyDir && !this.buildDir) {
       out.text("Argument --assembly-dir is obsolete. Please use --build-dir instead.")
       this.buildDir = this.assemblyDir;

--- a/src/commands/test/run/uitest.ts
+++ b/src/commands/test/run/uitest.ts
@@ -56,7 +56,9 @@ export default class RunUITestsCommand extends RunTestsCommand {
 
   constructor(args: CommandArgs) {
     super(args);
+  }
 
+  protected async runInner(): Promise<void> {
     if (this.assemblyDir && !this.buildDir) {
       out.text("Argument --assembly-dir is obsolete. Please use --build-dir instead.")
       this.buildDir = this.assemblyDir;


### PR DESCRIPTION
Otherwise:
- nothing is output
- the help command is broken