### PR TITLE
Remove apps' ID from console output

### DIFF
--- a/src/commands/apps/lib/format-app.ts
+++ b/src/commands/apps/lib/format-app.ts
@@ -4,7 +4,6 @@ import { models } from "../../../util/apis";
 export function reportApp(app: models.AppResponse): void {
   out.report(
   [
-    ["ID", "id" ],
     [ "App Secret", "appSecret" ],
     [ "Description", "description"],
     [ "Display Name", "displayName"],


### PR DESCRIPTION
Talked about this with @elamalani a couple of weeks ago.
The ID is currently of no use to the user and might potentially cause confusion.