### PR TITLE
Add `--language` parameter to `test run`

### DIFF
--- a/src/commands/test/lib/help-messages.ts
+++ b/src/commands/test/lib/help-messages.ts
@@ -43,7 +43,7 @@ export module Messages {
       export const PrepareArtifactsDir = "Path to artifacts directory to create";
       export const RunDevices = "Device selection slug";
       export const RunDSymDir = "Path to directory with iOS symbol files";
-      export const RunLocale = "The system locale for the test run. For example, en-US";
+      export const RunLocale = "The system locale for the test run. For example, en_US";
       export const RunLanguage = "Override language (iOS only) for the test run";
       export const RunTestSeries = "Name of the test series";
       export const RunAsync = "Exit the command when tests are uploaded, without waiting for test results";

--- a/src/commands/test/lib/help-messages.ts
+++ b/src/commands/test/lib/help-messages.ts
@@ -43,7 +43,8 @@ export module Messages {
       export const PrepareArtifactsDir = "Path to artifacts directory to create";
       export const RunDevices = "Device selection slug";
       export const RunDSymDir = "Path to directory with iOS symbol files";
-      export const RunLocale = "Locale (OS language) of the test run. For example, en-US";
+      export const RunLocale = "The system locale for the test run. For example, en-US";
+      export const RunLanguage = "Override language (iOS only) for the test run";
       export const RunTestSeries = "Name of the test series";
       export const RunAsync = "Exit the command when tests are uploaded, without waiting for test results";
 

--- a/src/commands/test/lib/run-tests-command.ts
+++ b/src/commands/test/lib/run-tests-command.ts
@@ -125,7 +125,6 @@ export class RunTestsCommand extends AppCommand {
     let manifest = JSON.parse(manifestJson) as ITestCloudManifestJson;
 
     await this.addIncludedFiles(path.dirname(manifestPath), manifest);
-    await this.addTestParameters(manifest);
 
     let modifiedJson = JSON.stringify(manifest, null, 1);
     await pfs.writeFile(manifestPath, modifiedJson);
@@ -169,6 +168,9 @@ export class RunTestsCommand extends AppCommand {
     uploader.locale = this.locale;
     uploader.testSeries = this.testSeries;
     uploader.dSymPath = this.dSymDir;
+    if (this.testParameters) {
+      uploader.testParameters = parseTestParameters(this.testParameters);
+    }
 
     return await uploader.uploadAndStart();
   }
@@ -195,14 +197,5 @@ export class RunTestsCommand extends AppCommand {
 
       manifest.files.push(includedFile.targetPath);
     }
-  }
-
-  protected async addTestParameters(manifest: ITestCloudManifestJson): Promise<void> {
-    if (!this.testParameters) {
-      return;
-    }
-
-    let parsedParameters = parseTestParameters(this.testParameters);
-    _.merge(manifest.testFramework.data, parsedParameters || {});
   }
 }

--- a/src/commands/test/lib/run-tests-command.ts
+++ b/src/commands/test/lib/run-tests-command.ts
@@ -87,7 +87,6 @@ export class RunTestsCommand extends AppCommand {
 
   public async run(client: MobileCenterClient): Promise<CommandResult> {
     await this.validateOptions();
-    await this.processLanguage();
     try {
       let artifactsDir = await this.getArtifactsDir();
 
@@ -166,6 +165,7 @@ export class RunTestsCommand extends AppCommand {
       this.devices);
 
     uploader.appPath = this.appPath;
+    uploader.language = this.language;
     uploader.locale = this.locale;
     uploader.testSeries = this.testSeries;
     uploader.dSymPath = this.dSymDir;
@@ -204,17 +204,5 @@ export class RunTestsCommand extends AppCommand {
 
     let parsedParameters = parseTestParameters(this.testParameters);
     _.merge(manifest.testFramework.data, parsedParameters || {});
-  }
-
-  private async processLanguage(): Promise<void> {
-    if (!this.language) {
-      return;
-    }
-    for (let index in this.testParameters) {
-      if (this.testParameters[index].indexOf("language=") === 0) {
-        throw new Error("Argument '--language' cannot be used with a 'language' test parameter");
-      }
-    }
-    this.testParameters.push("language=" + this.language);
   }
 }

--- a/src/commands/test/lib/run-tests-command.ts
+++ b/src/commands/test/lib/run-tests-command.ts
@@ -38,6 +38,11 @@ export class RunTestsCommand extends AppCommand {
   @hasArg
   locale: string;
 
+  @help(Messages.TestCloud.Arguments.RunLanguage)
+  @longName("language")
+  @hasArg
+  language: string;
+
   @help(Messages.TestCloud.Arguments.RunTestSeries)
   @longName("test-series")
   @hasArg
@@ -82,6 +87,7 @@ export class RunTestsCommand extends AppCommand {
 
   public async run(client: MobileCenterClient): Promise<CommandResult> {
     await this.validateOptions();
+    await this.processLanguage();
     try {
       let artifactsDir = await this.getArtifactsDir();
 
@@ -198,5 +204,17 @@ export class RunTestsCommand extends AppCommand {
 
     let parsedParameters = parseTestParameters(this.testParameters);
     _.merge(manifest.testFramework.data, parsedParameters || {});
+  }
+
+  private async processLanguage(): Promise<void> {
+    if (!this.language) {
+      return;
+    }
+    for (let index in this.testParameters) {
+      if (this.testParameters[index].indexOf("language=") === 0) {
+        throw new Error("Argument '--language' cannot be used with a 'language' test parameter");
+      }
+    }
+    this.testParameters.push("language=" + this.language);
   }
 }

--- a/src/commands/test/lib/test-cloud-uploader.ts
+++ b/src/commands/test/lib/test-cloud-uploader.ts
@@ -224,7 +224,7 @@ export class TestCloudUploader {
       locale: this.locale,
       language: this.language,
       testSeries: this.testSeries,
-      testParameters: this.testParameters
+      testParameters: allTestParameters
     };
 
     return clientCall(cb => {

--- a/src/commands/test/lib/test-cloud-uploader.ts
+++ b/src/commands/test/lib/test-cloud-uploader.ts
@@ -33,6 +33,7 @@ export class TestCloudUploader {
   public dSymPath: string;
   public testParameters: { [key:string]: any };
   public testSeries: string;
+  public language: string;
   public locale: string;
 
   constructor(client: MobileCenterClient, userName: string, appName: string, manifestPath: string, devices: string) {
@@ -221,6 +222,7 @@ export class TestCloudUploader {
       testFramework: manifest.testFramework.name,
       deviceSelection: this._devices,
       locale: this.locale,
+      language: this.language,
       testSeries: this.testSeries,
       testParameters: this.testParameters
     };

--- a/src/util/apis/generated/models/index.d.ts
+++ b/src/util/apis/generated/models/index.d.ts
@@ -3532,6 +3532,8 @@ export interface TestCloudHashUploadStatus {
  * 
  * @member {string} deviceSelection Device selection string.
  * 
+ * @member {string} [language] Language that should be used to run tests.
+ * 
  * @member {string} [locale] Locale that should be used to run tests.
  * 
  * @member {string} [testSeries] Name of the test series.
@@ -3543,6 +3545,7 @@ export interface TestCloudHashUploadStatus {
 export interface TestCloudStartTestRunOptions {
   testFramework: string;
   deviceSelection: string;
+  language?: string;
   locale?: string;
   testSeries?: string;
   testParameters?: any;

--- a/src/util/apis/generated/models/testCloudStartTestRunOptions.js
+++ b/src/util/apis/generated/models/testCloudStartTestRunOptions.js
@@ -18,6 +18,8 @@
  * 
  * @member {string} deviceSelection Device selection string.
  * 
+ * @member {string} [language] Language that should be used to run tests.
+ * 
  * @member {string} [locale] Locale that should be used to run tests.
  * 
  * @member {string} [testSeries] Name of the test series.
@@ -53,6 +55,13 @@ TestCloudStartTestRunOptions.prototype.mapper = function () {
         deviceSelection: {
           required: true,
           serializedName: 'device_selection',
+          type: {
+            name: 'String'
+          }
+        },
+        language: {
+          required: false,
+          serializedName: 'language',
           type: {
             name: 'String'
           }

--- a/src/util/apis/generated/operations/index.d.ts
+++ b/src/util/apis/generated/operations/index.d.ts
@@ -1404,6 +1404,9 @@ export interface Test {
      * 
      * @param {string} startOptions.deviceSelection Device selection string.
      * 
+     * @param {string} [startOptions.language] Language that should be used to run
+     * tests.
+     * 
      * @param {string} [startOptions.locale] Locale that should be used to run
      * tests.
      * 

--- a/src/util/apis/generated/operations/test.js
+++ b/src/util/apis/generated/operations/test.js
@@ -817,6 +817,9 @@ Test.prototype.getTestRunState = function (testRunId, ownerName, appName, option
  * 
  * @param {string} startOptions.deviceSelection Device selection string.
  * 
+ * @param {string} [startOptions.language] Language that should be used to run
+ * tests.
+ * 
  * @param {string} [startOptions.locale] Locale that should be used to run
  * tests.
  * 

--- a/swagger/bifrost.swagger.json
+++ b/swagger/bifrost.swagger.json
@@ -9417,6 +9417,10 @@
           "type": "string",
           "description": "Device selection string."
         },
+        "language": {
+          "type": "string",
+          "description": "Language that should be used to run tests."
+        },
         "locale": {
           "type": "string",
           "description": "Locale that should be used to run tests."


### PR DESCRIPTION
## Rebased 2017.02.17.11:31 GMT