### PR TITLE
Fix app path (not) required

### DIFF
--- a/src/commands/test/lib/run-tests-command.ts
+++ b/src/commands/test/lib/run-tests-command.ts
@@ -64,7 +64,7 @@ export abstract class RunTestsCommand extends AppCommand {
   @longName("async")
   async: boolean;
 
-  protected isAppPathRquired = false;
+  protected isAppPathRquired = true;
 
   constructor(args: CommandArgs) {
     super(args);

--- a/src/commands/test/run/manifest.ts
+++ b/src/commands/test/run/manifest.ts
@@ -12,7 +12,7 @@ export default class RunManifestTestsCommand extends RunTestsCommand {
   @required
   manifestPath: string;
 
-  protected isAppPathRquired = true;
+  protected isAppPathRquired = false;
 
   constructor(args: CommandArgs) {
     super(args);


### PR DESCRIPTION
App path is required for all commands except `manifest`, not only by `manifest`