### PR TITLE
CalabashPrepare: fixing regression when no test parameters are provided

### DIFF
--- a/src/commands/test/lib/calabash-preparer.ts
+++ b/src/commands/test/lib/calabash-preparer.ts
@@ -58,12 +58,11 @@ export class CalabashPreparer {
     if (this.skipConfigCheck) {
       command += " --skip-config-check";
     }
-
     if (this.signInfo) {
       command += ` --sign-info "${this.signInfo}"`;
     }
 
-    if (this.testParameters) {
+    if (this.testParameters && this.testParameters.length > 0) {
       command += ` --test-parameters ${this.generateTestParameterArgs()}`;
     }
 

--- a/src/commands/test/lib/calabash-preparer.ts
+++ b/src/commands/test/lib/calabash-preparer.ts
@@ -2,6 +2,7 @@ import { TestCloudError } from "./test-cloud-error";
 import { parseTestParameter } from "./parameters-parser";
 import * as path from "path";
 import * as process from "../../../util/misc/process-helper";
+import { out } from "../../../util/interaction";
 
 const debug = require("debug")("mobile-center-cli:commands:test:lib:calabash-preparer");
 
@@ -36,7 +37,7 @@ export class CalabashPreparer {
   public async prepare(): Promise<string> {
     let command = this.getPrepareCommand();
     debug(`Executing command ${command}`);
-    let exitCode = await process.execAndWait(command);
+    let exitCode = await process.execAndWait(command, this.outMessage, this.outMessage);
 
     if (exitCode !== 0) {
       throw new TestCloudError("Cannot prepare Calabash artifacts. Please inspect logs for more details", exitCode);
@@ -86,5 +87,24 @@ export class CalabashPreparer {
     }    
 
     return result;
+  }
+
+  /*
+   The Calabash `test-cloud prepare` command uses different argument names than the Mobile Center CLI.
+   We cannot easily change that: the `test-cloud prepare` uses argument names that are consistent with other 
+   `test-cloud` commands, while the `mobile-center test run calabash` uses argument names that are consistent with 
+   other Mobile Center CLI commands.
+
+   As a result, user who uses Mobile Center CLI will see misleading error messages, such as:
+    `The --profile option was set without a --config option.`
+   
+   However, when user tries again with the --config option, he will see another error message, since the correct name 
+   for Mobile Center CLI is `--config-path`.
+
+   The easiest way to make the experience better is to translate the messages.
+  */
+  private outMessage(line: string) {
+    let translatedCalabashMessage = line.replace("--config ", "--config-path ");
+    out.text(translatedCalabashMessage);
   }
 }

--- a/src/commands/test/lib/run-tests-command.ts
+++ b/src/commands/test/lib/run-tests-command.ts
@@ -168,6 +168,7 @@ export class RunTestsCommand extends AppCommand {
     uploader.locale = this.locale;
     uploader.testSeries = this.testSeries;
     uploader.dSymPath = this.dSymDir;
+
     if (this.testParameters) {
       uploader.testParameters = parseTestParameters(this.testParameters);
     }

--- a/src/commands/test/prepare/calabash.ts
+++ b/src/commands/test/prepare/calabash.ts
@@ -66,6 +66,10 @@ export default class PrepareCalabashCommand extends PrepareTestsCommand {
       this.configPath = this.config;
     }
 
+    if (this.config && this.configPath) {
+      throw new Error("Both arguments --config-path and --config (obsolete) were used. Please use only --config-path.")
+    }
+
     if (!this.projectDir) {
       throw new Error("Argument --project-dir is required");
     }

--- a/src/commands/test/prepare/calabash.ts
+++ b/src/commands/test/prepare/calabash.ts
@@ -32,10 +32,15 @@ export default class PrepareCalabashCommand extends PrepareTestsCommand {
   @hasArg
   signInfo: string;
 
-  @help(Messages.TestCloud.Arguments.CalabashConfigPath)
+  @help("Obsolete. Please use --config-path instead")
   @longName("config")
   @hasArg
   config: string;
+
+  @help(Messages.TestCloud.Arguments.CalabashConfigPath)
+  @longName("config-path")
+  @hasArg
+  configPath: string;
 
   @help(Messages.TestCloud.Arguments.CalabashProfile)
   @longName("profile")
@@ -56,6 +61,11 @@ export default class PrepareCalabashCommand extends PrepareTestsCommand {
       this.projectDir = this.workspaceDir;
     }
 
+    if (this.config && !this.configPath) {
+      out.text("Argument --config is obsolete. Please use --config-path instead.");
+      this.configPath = this.config;
+    }
+
     if (!this.projectDir) {
       throw new Error("Argument --project-dir is required");
     }
@@ -65,7 +75,7 @@ export default class PrepareCalabashCommand extends PrepareTestsCommand {
     let preparer = new CalabashPreparer(this.artifactsDir, this.projectDir, this.appPath, this.testParameters);
 
     preparer.signInfo = this.signInfo;
-    preparer.config = this.config;
+    preparer.config = this.configPath;
     preparer.profile = this.profile;
     preparer.skipConfigCheck = this.skipConfigCheck;
 

--- a/src/commands/test/prepare/calabash.ts
+++ b/src/commands/test/prepare/calabash.ts
@@ -64,12 +64,12 @@ export default class PrepareCalabashCommand extends PrepareTestsCommand {
   protected prepareManifest(): Promise<string> {
     let preparer = new CalabashPreparer(this.artifactsDir, this.projectDir, this.appPath, this.testParameters);
 
-      preparer.signInfo = this.signInfo;
-      preparer.config = this.config;
-      preparer.profile = this.profile;
-      preparer.skipConfigCheck = this.skipConfigCheck;
+    preparer.signInfo = this.signInfo;
+    preparer.config = this.config;
+    preparer.profile = this.profile;
+    preparer.skipConfigCheck = this.skipConfigCheck;
 
-      return preparer.prepare();
+    return preparer.prepare();
   }
 
   protected getSourceRootDir() {

--- a/src/commands/test/prepare/calabash.ts
+++ b/src/commands/test/prepare/calabash.ts
@@ -61,13 +61,13 @@ export default class PrepareCalabashCommand extends PrepareTestsCommand {
       this.projectDir = this.workspaceDir;
     }
 
+    if (this.config && this.configPath) {
+      throw new Error("Both arguments --config-path and --config (obsolete) were used. Please use only --config-path.")
+    }
+
     if (this.config && !this.configPath) {
       out.text("Argument --config is obsolete. Please use --config-path instead.");
       this.configPath = this.config;
-    }
-
-    if (this.config && this.configPath) {
-      throw new Error("Both arguments --config-path and --config (obsolete) were used. Please use only --config-path.")
     }
 
     if (!this.projectDir) {

--- a/src/commands/test/prepare/calabash.ts
+++ b/src/commands/test/prepare/calabash.ts
@@ -62,10 +62,10 @@ export default class PrepareCalabashCommand extends PrepareTestsCommand {
     }
 
     if (this.config && this.configPath) {
-      throw new Error("Both arguments --config-path and --config (obsolete) were used. Please use only --config-path.")
+      throw new Error("Arguments --config-path and --config (obsolete) were both used. Please use only --config-path.")
     }
 
-    if (this.config && !this.configPath) {
+    if (this.config) {
       out.text("Argument --config is obsolete. Please use --config-path instead.");
       this.configPath = this.config;
     }

--- a/src/util/misc/process-helper.ts
+++ b/src/util/misc/process-helper.ts
@@ -1,9 +1,17 @@
 import * as child_process from "child_process";
 import { out } from "../interaction";
 
-export function execAndWait(command: string): Promise<number> {
+export function execAndWait(command: string, onStdOut?: (text: string) => void, onStdErr?: (text: string) => void): Promise<number> {
   return new Promise((resolve, reject) => {
+    if (!onStdOut) {
+      onStdOut = text => out.text(text);
+    }
+    if (!onStdErr) {
+      onStdErr = text => out.text(text);
+    }
+
     let process = child_process.exec(command);
+
     process.on("exit", (exitCode: number) => {
       resolve(exitCode);
     })
@@ -13,11 +21,11 @@ export function execAndWait(command: string): Promise<number> {
     });
 
     process.stdout.on("data", data => {
-      out.text(data as string);
+      onStdOut(data as string);
     });
 
     process.stderr.on("data", data => {
-      out.text(data as string);
+      onStdErr(data as string);
     });
   });
 }


### PR DESCRIPTION
Fixes a regression introduced with a recent fix for test parameters.

With the latest fix, we pass empty test parameters array to the `CalabashPreparer` if no parameters are used. However, the preparer was not handling it correctly, and generated empty `--test-parameters` argument passed to the Ruby CLI `test-cloud`. The Ruby CLI couldn't parse it, and returned a failure.

