### PR TITLE
Fixed Nock-dependent tests

### DIFF
--- a/src/util/apis/user-agent-filter.ts
+++ b/src/util/apis/user-agent-filter.ts
@@ -8,6 +8,6 @@ import { scriptName } from "../misc";
 const { version: cliVersion } = require("../../../package.json");
 
 export function userAgentFilter(resource: WebResource, next: any, callback: any): any {
-  resource.withHeader("User-Agent", `${scriptName}Cli/${cliVersion} NodeJS/${process.version} ${platform()}/${release()}`);
+  resource.withHeader("user-agent", `${scriptName}Cli/${cliVersion} NodeJS/${process.version} ${platform()}/${release()}`);
   return next(resource, callback);
 }


### PR DESCRIPTION
Recently I have noticed that 'upload-symbols' tests are crashing.

I have found that tests themselves are OK, and Nock is a source of crashes.
The exception contains the following message: 
`"Failed to convert header keys to lower case due to field name conflict: user-agent"`
It is thrown in the node_modules\nock\lib\common.js, when Nock tries to normalize the incoming headers by lowercasing their names:

``` //  For each key in the headers, delete its value and reinsert it with lower-case key.
  //  Keys represent headers field names.
  var lowerCaseHeaders = {};
  _.forOwn(headers, function(fieldVal, fieldName) {
    var lowerCaseFieldName = fieldName.toLowerCase();
    if(!_.isUndefined(lowerCaseHeaders[lowerCaseFieldName])) {
      throw new Error('Failed to convert header keys to lower case due to field name conflict: ' + lowerCaseFieldName);
    }
    lowerCaseHeaders[lowerCaseFieldName] = fieldVal;
  });
```

The crash happened because there were two headers for user agent - "User-Agent" and "user-agent'
The first one is added by user-agent-filter.ts, while the second one is inserted by ms-rest in node_modules\ms-rest\userAgentFilter.js:

```/**
* Creates a filter to add the user agent header in a request.
*
* @param {string} userAgent The user agent string to use.
*/
exports.create = function (userAgentInfo) {
  return function handle(resource, next, callback) {
    if (!resource.headers[HeaderConstants.USER_AGENT]) {
      exports.tagRequest(resource, userAgentInfo);
    }

    return next(resource, callback);
  };
};

exports.tagRequest = function (requestOptions, userAgentInfo) {
  var runtimeInfo = util.format('Node/%s', process.version);
  var osInfo = util.format('(%s-%s-%s)', os.arch(), os.type(), os.release());
  userAgentInfo.unshift(runtimeInfo, osInfo);
  requestOptions.headers[HeaderConstants.USER_AGENT] = userAgentInfo.join(' ');
};
```

It checks if "user-agent" header doesn't exist before inserting the default one, but doesn't take into account that existing header may contain upper-case letters. This is the source of the issue.
When the user agent header is generated with all-lowercase name in user-agent-filter.ts, the problem no longer exists.