### PR TITLE
Implemented 'build branches list' command

### DIFF
--- a/scripts/autorest.js
+++ b/scripts/autorest.js
@@ -112,6 +112,9 @@ function fixupRawSwagger(rawSwaggerPath, fixedSwaggerPath) {
     if (_.isEmpty(swagger.paths[urlPath])) {
       delete swagger.paths[urlPath];
     } else {
+      if (urlPath === '/v0.1/apps/{owner_name}/{app_name}/commits/batch/{sha_collection}') {
+        fixupGetCommits(swagger.paths[urlPath]);
+      }
       let operations = _.toPairs(swagger.paths[urlPath]);
       operations.forEach(([method, operationObj]) => {
         if (!operationIdIsValid(operationObj)) {
@@ -170,6 +173,30 @@ function urlPathToOperation(urlPath) {
     .map(removeIllegalCharacters)
     .map(snakeToPascalCase)
     .join('');
+}
+
+function fixupGetCommits(operations) {
+  let getCommits = operations['get'];
+  if (!getCommits) {
+    console.error('Could not find getCommits operation!');
+    return;
+  }
+
+  let parameters = getCommits.parameters;
+  if(!parameters) {
+    console.error('Could not find parameters for get operation!');
+    return;
+  }
+
+  let shaCollection = parameters.filter(p => p.name && p.name === 'sha_collection');
+  if (shaCollection.length !== 1) {
+    return;
+  }
+
+  let shaCollectionParam = shaCollection[0];
+  if (!shaCollectionParam['x-ms-skip-url-encoding']) {
+    shaCollectionParam['x-ms-skip-url-encoding'] = true;
+  }
 }
 
 module.exports = {

--- a/src/commands/build/branches/lib/format-build.ts
+++ b/src/commands/build/branches/lib/format-build.ts
@@ -1,0 +1,25 @@
+import { DefaultApp } from "../../../../util/profile";
+import { models } from "../../../../util/apis";
+import * as PortalHelper from "../../../../util/portal/portal-helper";
+import { out } from "../../../../util/interaction";
+import * as _ from "lodash";
+
+export function reportBuild(build: models.Build, commitInfo: models.CommitDetails, app: DefaultApp, portalBaseUrl: string) {
+  const outputObject = _.extend(_.clone(build), {
+    author: `${commitInfo.commit.author.name} <${commitInfo.commit.author.email}>`,
+    message: commitInfo.commit.message,
+    sha: commitInfo.sha,
+    url: PortalHelper.getPortalBuildLink(portalBaseUrl, app.ownerName, app.appName, build.sourceBranch, build.id.toString())
+  });
+
+  out.report([
+    ["Branch", "sourceBranch"],
+    ["Build number", "buildNumber"],
+    ["Build status", "status"],
+    ["Build result", "result"],
+    ["Build URL", "url"],
+    ["Commit author", "author"],
+    ["Commit message", "message"],
+    ["Commit SHA", "sha"],
+  ], outputObject);
+}

--- a/src/commands/build/branches/list.ts
+++ b/src/commands/build/branches/list.ts
@@ -1,0 +1,62 @@
+import { reportBuild } from "./lib/format-build";
+import {AppCommand, Command, CommandArgs, CommandResult, ErrorCodes, failure, hasArg, help, longName, required, shortName, success} from "../../../util/commandline";
+import { MobileCenterClient, models, clientRequest } from "../../../util/apis";
+import { out } from "../../../util/interaction";
+import * as _ from "lodash";
+
+const debug = require("debug")("mobile-center-cli:commands:build:branches:list");
+
+@help("Show list of branches")
+export default class ShowBranchesListBuildStatusCommand extends AppCommand {
+
+  async run(client: MobileCenterClient, portalBaseUrl: string): Promise<CommandResult> {
+    const app = this.app;
+
+    debug(`Getting list of branches for app ${app.appName}`);
+    const branchesStatusesRequestResponse = await out.progress(`Getting statuses for branches of app ${app.appName}...`, 
+      clientRequest<models.BranchStatus[]>((cb) => client.buildOperations.getBranches(app.ownerName, app.appName, cb)));
+
+    const branchBuildsHttpResponseCode = branchesStatusesRequestResponse.response.statusCode;
+
+    if (branchBuildsHttpResponseCode >= 400) {
+      return failure(ErrorCodes.Exception, "the Branches List request was rejected for an unknown reason");
+    }
+
+    const branchesWithBuilds = _(branchesStatusesRequestResponse.result)
+      .filter((branch) => !_.isNil(branch.lastBuild))
+      .sortBy((b) => b.lastBuild.sourceBranch)
+      .value();
+
+    if (branchesWithBuilds.length === 0) {
+      out.text(`There are no configured branches for the app ${app.appName}`);
+      return success();
+    }
+
+    const buildShas = branchesWithBuilds.map((branch) => branch.lastBuild.sourceVersion);
+
+    debug("Getting commit info for the last builds of the branches");
+    const commitInfoRequestResponse = await out.progress("Getting commit info for the last builds of branches...", 
+      clientRequest<models.CommitDetails[]>((cb) => client.buildOperations.getCommits(buildShas.join(","), app.ownerName, app.appName, cb)));
+
+    const commitInfoRequestResponseResponseCode = commitInfoRequestResponse.response.statusCode;
+
+    if (commitInfoRequestResponseResponseCode >= 400) {
+      return failure(ErrorCodes.Exception, "the Get Commits request was rejected for an unknown reason");
+    }
+
+    const commits = commitInfoRequestResponse.result;
+
+    for (let i = 0; i < branchesWithBuilds.length; i++) {
+      const branchBuild = branchesWithBuilds[i].lastBuild;
+      const branchCommit = commits[i];
+
+      if (i) {
+        out.text("");
+      }
+
+      reportBuild(branchBuild, branchCommit, app, portalBaseUrl);
+    }
+
+    return success();
+  }
+}

--- a/src/commands/build/branches/show.ts
+++ b/src/commands/build/branches/show.ts
@@ -2,7 +2,7 @@ import {AppCommand, Command, CommandArgs, CommandResult, ErrorCodes, failure, ha
 import { MobileCenterClient, models, clientRequest } from "../../../util/apis";
 import { out } from "../../../util/interaction";
 import * as _ from "lodash";
-import * as PortalHelper from "../../../util/portal/portal-helper";
+import { reportBuild } from "./lib/format-build";
 
 const debug = require("debug")("mobile-center-cli:commands:build:branches:show");
 
@@ -51,23 +51,7 @@ export default class ShowBranchBuildStatusCommand extends AppCommand {
 
     const commitInfo = commitInfoRequestResponse.result[0];
 
-    const outputObject = _.extend(_.clone(lastBuild), {
-      author: `${commitInfo.commit.author.name} <${commitInfo.commit.author.email}>`,
-      message: commitInfo.commit.message,
-      sha: commitInfo.sha,
-      url: PortalHelper.getPortalBuildLink(portalBaseUrl, app.ownerName, app.appName, lastBuild.sourceBranch, lastBuild.id.toString())
-    });
-
-    out.report([
-      ["Branch", "sourceBranch"],
-      ["Build number", "buildNumber"],
-      ["Build status", "status"],
-      ["Build result", "result"],
-      ["Build URL", "url"],
-      ["Commit author", "author"],
-      ["Commit message", "message"],
-      ["Commit SHA", "sha"],
-    ], outputObject);
+    reportBuild(lastBuild, commitInfo, app, portalBaseUrl);
 
     return success();
   }

--- a/src/util/apis/generated/operations/buildOperations.js
+++ b/src/util/apis/generated/operations/buildOperations.js
@@ -860,7 +860,7 @@ BuildOperations.prototype.getCommits = function (shaCollection, ownerName, appNa
   // Construct URL
   var baseUrl = this.client.baseUri;
   var requestUrl = baseUrl + (baseUrl.endsWith('/') ? '' : '/') + 'v0.1/apps/{owner_name}/{app_name}/commits/batch/{sha_collection}';
-  requestUrl = requestUrl.replace('{sha_collection}', encodeURIComponent(shaCollection));
+  requestUrl = requestUrl.replace('{sha_collection}', shaCollection);
   requestUrl = requestUrl.replace('{owner_name}', encodeURIComponent(ownerName));
   requestUrl = requestUrl.replace('{app_name}', encodeURIComponent(appName));
   var queryParameters = [];

--- a/swagger/bifrost.swagger.json
+++ b/swagger/bifrost.swagger.json
@@ -5347,7 +5347,8 @@
             "type": "string",
             "in": "path",
             "description": "A collection of commit SHAs comma-delimited",
-            "required": true
+            "required": true,
+            "x-ms-skip-url-encoding": true
           },
           {
             "$ref": "#/parameters/form"


### PR DESCRIPTION
Implemented 'build branches list' command:
![capture](https://cloud.githubusercontent.com/assets/25530829/23754105/e475bb56-04ec-11e7-8b1d-73d21cbeb22f.PNG)

Refactored 'build branches show' to extract common output logic.

Depends on #135 for 'build branches show' implementation