### PR TITLE
Download swagger automatically & new swagger fixups

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "watch-test": "mocha --compilers ts:ts-node/register --recursive ./test/**/*-test.[tj]s --watch",
     "autorest": "gulp autorest",
     "clean": "gulp clean",
-    "prepublish": "gulp prepublish"
+    "prepublish": "gulp prepublish",
+    "download-swagger": "gulp download-swagger"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
You can now do:

```
gulp autorest --env <dev|int>
```

or

```
npm run autorest -- --env <dev|int>
```

to download and regenerate the client in one shot.

Added fixups to work around autorest issue https://github.com/Azure/autorest/issues/2008.

Broke out individual parts of codegen into separate gulp tasks so you can generate without downloading for example.
