### PR TITLE
"-v" switch works correctly when used with a command having required arguments

### DIFF
--- a/src/commands/build/branches/lib/format-build.ts
+++ b/src/commands/build/branches/lib/format-build.ts
@@ -14,7 +14,7 @@ export function reportBuild(build: models.Build, commitInfo: models.CommitDetail
 
   out.report([
     ["Branch", "sourceBranch"],
-    ["Build number", "buildNumber"],
+    ["Build ID", "buildNumber"],
     ["Build status", "status"],
     ["Build result", "result"],
     ["Build URL", "url"],

--- a/src/util/commandline/option-parser.ts
+++ b/src/util/commandline/option-parser.ts
@@ -111,8 +111,8 @@ export function parseOptions(...params: any[]): void {
     const option = flagOptions[targetPropertyName];
     const optKey = optionKey(option);
 
-    // Skip required args if help has been invoked
-    if (!parsed["help"] && option.required && !parsed[optKey]) {
+    // Skip required args if help or version have been invoked
+    if (!parsed["help"] && !parsed["version"] && option.required && !parsed[optKey]) {
       // TODO: Replace this with auto-prompting
       throw new Error(`Missing required option ${optionDisplayName(option)}`);
     }


### PR DESCRIPTION
This PR fixes the problem described in [the task](https://mseng.visualstudio.com/Mobile%20Center/Command%20Line%20Interface/_workitems?id=951461&_a=edit). It is not specific for the "build" commands and occurs for any command having required arguments (e.g. "apps create").