### PR TITLE
Moved CommandFailedResult exceptions handling to the command-runner.ts

### DIFF
--- a/src/commands/build/download.ts
+++ b/src/commands/build/download.ts
@@ -1,4 +1,4 @@
-import {AppCommand, Command, CommandArgs, CommandResult, ErrorCodes, failure, hasArg, help, longName, required, shortName, success, isCommandFailedResult} from "../../util/commandline";
+import {AppCommand, Command, CommandArgs, CommandResult, ErrorCodes, failure, hasArg, help, longName, required, shortName, success } from "../../util/commandline";
 import { MobileCenterClient, models, clientRequest, ClientResponse } from "../../util/apis";
 import { out } from "../../util/interaction";
 import { inspect } from "util";
@@ -47,18 +47,6 @@ export default class DownloadBuildStatusCommand extends AppCommand {
   public directory: string;
 
   public async run(client: MobileCenterClient): Promise<CommandResult> {
-    try {
-      return await this.doCommand(client);
-    } catch (error) {
-      if (isCommandFailedResult(error)) {
-        return error;
-      } else {
-        throw error;
-      }
-    }
-  }
-
-  private async doCommand(client: MobileCenterClient): Promise<CommandResult> {
     this.type = this.getNormalizedTypeValue(this.type);
 
     const buildIdNumber = this.getNormalizedBuildId(this.buildId);

--- a/src/commands/distribute/groups/create.ts
+++ b/src/commands/distribute/groups/create.ts
@@ -1,4 +1,4 @@
-import { AppCommand, CommandResult, ErrorCodes, failure, help, success, shortName, longName, required, hasArg, isCommandFailedResult} from "../../../util/commandline";
+import { AppCommand, CommandResult, ErrorCodes, failure, help, success, shortName, longName, required, hasArg } from "../../../util/commandline";
 import { MobileCenterClient, models, clientRequest } from "../../../util/apis";
 import { out } from "../../../util/interaction";
 import { inspect } from "util";
@@ -31,18 +31,6 @@ export default class CreateDistributionGroupCommand extends AppCommand {
   public testersListFile: string;
 
   public async run(client: MobileCenterClient): Promise<CommandResult> {
-    try {
-      return await this.doCommand(client);
-    } catch (error) {
-      if (isCommandFailedResult(error)) {
-        return error;
-      } else {
-        throw error;
-      }
-    }
-  }
-
-  private async doCommand(client: MobileCenterClient): Promise<CommandResult> {
     const app = this.app;
 
     // validate that 'testers' and 'testers-file' are not specified simultaneously

--- a/src/commands/distribute/groups/download.ts
+++ b/src/commands/distribute/groups/download.ts
@@ -1,4 +1,4 @@
-import { AppCommand, CommandResult, help, success, failure, shortName, longName, required, hasArg, isCommandFailedResult, ErrorCodes } from "../../../util/commandline";
+import { AppCommand, CommandResult, help, success, failure, shortName, longName, required, hasArg, ErrorCodes } from "../../../util/commandline";
 import { MobileCenterClient, clientRequest, models } from "../../../util/apis";
 import { out } from "../../../util/interaction";
 import { DefaultApp } from "../../../util/profile";
@@ -41,17 +41,6 @@ export default class DownloadBinaryFromDistributionGroupCommand extends AppComma
   public directory: string;
 
   public async run(client: MobileCenterClient): Promise<CommandResult> {
-    try {
-      return await this.doCommand(client);
-    } catch (error) {
-      if (isCommandFailedResult(error)) {
-        return error;
-      } else {
-        throw error;
-      }
-    }
-  }
-  private async doCommand(client: MobileCenterClient): Promise<CommandResult> {
     const app = this.app;
 
     // test that optional release id is a positive integer and optional file name is valid

--- a/src/commands/distribute/groups/lib/group-view-helper.ts
+++ b/src/commands/distribute/groups/lib/group-view-helper.ts
@@ -28,7 +28,7 @@ export async function showDistributionGroupView(client: MobileCenterClient, app:
     }
   } catch (error) {
     if (error === 404) {
-      return failure(ErrorCodes.InvalidParameter, `distribution group ${distributionGroup} was not found`);
+      throw failure(ErrorCodes.InvalidParameter, `distribution group ${distributionGroup} was not found`);
     } else {
       debug(`Failed to get list of distribution group members - ${inspect(error)}`);
       throw failure(ErrorCodes.Exception, "failed to retrieve list of distribution group users");

--- a/src/commands/distribute/groups/show.ts
+++ b/src/commands/distribute/groups/show.ts
@@ -1,4 +1,4 @@
-import { AppCommand, CommandResult, help, success, shortName, longName, required, hasArg, isCommandFailedResult } from "../../../util/commandline";
+import { AppCommand, CommandResult, help, success, shortName, longName, required, hasArg } from "../../../util/commandline";
 import { MobileCenterClient } from "../../../util/apis";
 
 import { showDistributionGroupView } from "./lib/group-view-helper";
@@ -18,15 +18,7 @@ export default class ShowDistributionGroupCommand extends AppCommand {
     const app = this.app;
 
     // showing distribution group view
-    try {
-      await showDistributionGroupView(client, app, this.distributionGroup, debug);
-    } catch (error) {
-      if (isCommandFailedResult(error)) {
-        return error;
-      } else {
-        throw error;
-      }
-    }
+    await showDistributionGroupView(client, app, this.distributionGroup, debug);
 
     return success();
   }

--- a/src/commands/distribute/groups/update.ts
+++ b/src/commands/distribute/groups/update.ts
@@ -1,4 +1,4 @@
-import { AppCommand, CommandResult, ErrorCodes, failure, help, success, shortName, longName, required, hasArg, isCommandFailedResult} from "../../../util/commandline";
+import { AppCommand, CommandResult, ErrorCodes, failure, help, success, shortName, longName, required, hasArg } from "../../../util/commandline";
 import { MobileCenterClient, models, clientRequest } from "../../../util/apis";
 import { out } from "../../../util/interaction";
 import { inspect } from "util";
@@ -50,18 +50,6 @@ export default class UpdateDistributionGroupCommand extends AppCommand {
   public testersToDeleteListFile: string;
 
   public async run(client: MobileCenterClient): Promise<CommandResult> {
-    try {
-      return await this.doCommand(client);
-    } catch (error) {
-      if (isCommandFailedResult(error)) {
-        return error;
-      } else {
-        throw error;
-      }
-    }
-  }
-
-  private async doCommand(client: MobileCenterClient): Promise<CommandResult> {
     const app = this.app;
 
     // validate that string and file properties are not specified simultaneously

--- a/src/commands/distribute/release.ts
+++ b/src/commands/distribute/release.ts
@@ -1,4 +1,4 @@
-import { AppCommand, CommandResult, ErrorCodes, failure, hasArg, help, isCommandFailedResult, longName, required, shortName, success} from "../../util/commandline";
+import { AppCommand, CommandResult, ErrorCodes, failure, hasArg, help, longName, required, shortName, success } from "../../util/commandline";
 import { MobileCenterClient, models, clientRequest, ClientResponse } from "../../util/apis";
 import { out } from "../../util/interaction";
 import { inspect } from "util";
@@ -39,18 +39,6 @@ export default class ReleaseBinaryCommand extends AppCommand {
   public releaseNotesFile: string;
 
   public async run(client: MobileCenterClient): Promise<CommandResult> {
-    try {
-      return await this.doCommand(client);
-    } catch (error) {
-      if (isCommandFailedResult(error)) {
-        return error;
-      } else {
-        throw error;
-      }
-    }
-  }
-
-  private async doCommand(client: MobileCenterClient): Promise<CommandResult> {
     const app: DefaultApp = this.app;
     
     debug("Check that user hasn't selected both --release-notes and --release-notes-file");

--- a/src/util/commandline/command-runner.ts
+++ b/src/util/commandline/command-runner.ts
@@ -1,7 +1,7 @@
 // logic that reads a command line, extracts the actual command, and loads it.
 
 import { Command } from "./command";
-import { CommandResult, exception, illegal, notFound } from "./command-result";
+import { CommandResult, exception, illegal, notFound, isCommandFailedResult } from "./command-result";
 import * as Finder from "./command-finder";
 import * as Loader from "./command-loader";
 import { setDebug, isDebug, setFormatJson } from "../interaction";
@@ -49,6 +49,9 @@ function runner(arg: any): CommandRunner {
       return await commandObj.execute();
     }
     catch (ex) {
+      if (isCommandFailedResult(ex)) {
+        return ex;
+      }
       if(isDebug()) {
         console.log(`Command Failure at ${ex.stack}`);
       }

--- a/test/commands/distribute/release/release-test.ts
+++ b/test/commands/distribute/release/release-test.ts
@@ -1,9 +1,12 @@
-import { expect } from "chai";
+import { expect, use } from "chai";
 import * as Fs from "fs";
 import * as Nock from "nock";
 import * as Path from "path";
 import * as Sinon from "sinon";
 import * as Temp from "temp";
+import * as ChaiAsPromised from "chai-as-promised";
+
+use(ChaiAsPromised);
 
 import ReleaseBinaryCommand from "../../../../src/commands/distribute/release";
 import { CommandArgs, CommandResult } from "../../../../src/util/commandline";
@@ -113,7 +116,7 @@ describe("release command", () => {
 
       // Act 
       const command = new ReleaseBinaryCommand(getCommandArgs(["-f", releaseFilePath, "-R", releaseNotesFilePath, "-g", fakeDistributionGroupName]));
-      const result = await command.execute();
+      const result = await expect(command.execute()).to.eventually.be.rejected;
 
       // Assert
       testUploadFailure(result, expectedRequestsScope, skippedRequestsScope);


### PR DESCRIPTION
Moved CommandFailedResult exceptions handling to the command-runner.ts and fixed test which was not handling the promise rejection before this change