### PR TITLE
Test Cloud commands: adding timeout and fixing "please inspect logs" messages

### DIFF
--- a/bin/mobile-center.js
+++ b/bin/mobile-center.js
@@ -36,7 +36,7 @@ function runCli() {
   runner(process.argv.slice(2))
     .then(function (result) {
       if (commandLine.failed(result)) {
-        console.log(`Command failed, ${result.errorMessage}`);
+        console.log(`Command failed: ${result.errorMessage}`);
         process.exit(result.errorCode);
       }
     });

--- a/src/commands/test/lib/calabash-preparer.ts
+++ b/src/commands/test/lib/calabash-preparer.ts
@@ -40,7 +40,7 @@ export class CalabashPreparer {
     let exitCode = await process.execAndWait(command, this.outMessage, this.outMessage);
 
     if (exitCode !== 0) {
-      throw new TestCloudError(`cannot prepare Calabash artifacts. Returning exit code ${exitCode}.`, exitCode);
+      throw new TestCloudError(`Cannot prepare Calabash artifacts. Returning exit code ${exitCode}.`, exitCode);
     }
 
     return path.join(this.artifactsDir, "manifest.json");

--- a/src/commands/test/lib/calabash-preparer.ts
+++ b/src/commands/test/lib/calabash-preparer.ts
@@ -40,7 +40,7 @@ export class CalabashPreparer {
     let exitCode = await process.execAndWait(command, this.outMessage, this.outMessage);
 
     if (exitCode !== 0) {
-      throw new TestCloudError("Cannot prepare Calabash artifacts. Please inspect logs for more details", exitCode);
+      throw new TestCloudError(`cannot prepare Calabash artifacts. Returning exit code ${exitCode}.`, exitCode);
     }
 
     return path.join(this.artifactsDir, "manifest.json");

--- a/src/commands/test/lib/exit-codes.ts
+++ b/src/commands/test/lib/exit-codes.ts
@@ -1,0 +1,6 @@
+export module ExitCodes {
+  export const Success: number = 0;
+  
+  // Exit codes between 1 and 63 are reserved for Test Cloud backend.
+  export const Timeout: number = 64;
+}

--- a/src/commands/test/lib/help-messages.ts
+++ b/src/commands/test/lib/help-messages.ts
@@ -49,6 +49,7 @@ export module Messages {
       export const RunLanguage = "Override the language (iOS only) for the test run";
       export const RunTestSeries = "Name of the test series";
       export const RunAsync = "Exit the command when tests are uploaded, without waiting for test results";
+      export const Timeout = "Maximum time (in seconds) to wait for test results";
 
       export const AppiumBuildDir = "Path to the directory with the Appium tests (usually <project>/target/upload)";
       

--- a/src/commands/test/lib/run-tests-command.ts
+++ b/src/commands/test/lib/run-tests-command.ts
@@ -189,7 +189,7 @@ export abstract class RunTestsCommand extends AppCommand {
     let exitCode = await checker.checkUntilCompleted(this.timeoutSec);
 
     if (exitCode !== 0) {
-      throw new TestCloudError("Test run failed. Please inspect logs for more details", exitCode);
+      throw new TestCloudError(`cannot run Test Cloud tests. Returning exit code ${exitCode}.`, exitCode);
     }
   }
 

--- a/src/commands/test/lib/run-tests-command.ts
+++ b/src/commands/test/lib/run-tests-command.ts
@@ -189,7 +189,7 @@ export abstract class RunTestsCommand extends AppCommand {
     let exitCode = await checker.checkUntilCompleted(this.timeoutSec);
 
     if (exitCode !== 0) {
-      throw new TestCloudError(`cannot run Test Cloud tests. Returning exit code ${exitCode}.`, exitCode);
+      throw new TestCloudError(`Cannot run Test Cloud tests. Returning exit code ${exitCode}.`, exitCode);
     }
   }
 

--- a/src/commands/test/lib/run-tests-command.ts
+++ b/src/commands/test/lib/run-tests-command.ts
@@ -64,6 +64,11 @@ export abstract class RunTestsCommand extends AppCommand {
   @longName("async")
   async: boolean;
 
+  @help(Messages.TestCloud.Arguments.Timeout)
+  @longName("timeout")
+  @hasArg
+  timeoutSec: number;
+
   protected isAppPathRquired = true;
 
   constructor(args: CommandArgs) {
@@ -81,6 +86,10 @@ export abstract class RunTestsCommand extends AppCommand {
     }
     else if (typeof this.include === "string") {
       this.include = [ this.include ];
+    }
+
+    if (this.timeoutSec && typeof this.timeoutSec === "string") {
+      this.timeoutSec = parseInt(this.timeoutSec);
     }
   }
 
@@ -177,7 +186,7 @@ export abstract class RunTestsCommand extends AppCommand {
 
   private async waitForCompletion(client: MobileCenterClient, testRunId: string): Promise<void> {
     let checker = new StateChecker(client, testRunId, this.app.ownerName, this.app.appName);
-    let exitCode = await checker.checkUntilCompleted();
+    let exitCode = await checker.checkUntilCompleted(this.timeoutSec);
 
     if (exitCode !== 0) {
       throw new TestCloudError("Test run failed. Please inspect logs for more details", exitCode);

--- a/src/commands/test/lib/state-checker.ts
+++ b/src/commands/test/lib/state-checker.ts
@@ -34,7 +34,7 @@ export class StateChecker {
         let elapsedSeconds = process.hrtime(startTime)[0];
         if (elapsedSeconds + state.waitTime > timeoutSec) {
           exitCode = ExitCodes.Timeout;
-          out.text(`Command timed out waiting for tests to finish after ${timeoutSec} sec. Returning exit code ${exitCode}.`)
+          out.text(`After ${timeoutSec} seconds, command timed out waiting for tests to finish.`)
           break;
         }
       }

--- a/src/commands/test/lib/uitest-preparer.ts
+++ b/src/commands/test/lib/uitest-preparer.ts
@@ -44,7 +44,7 @@ export class UITestPreparer {
     let exitCode = await process.execAndWait(command);
 
     if (exitCode !== 0) {
-      throw new TestCloudError(`cannot prepare UI Test artifacts. Returning exit code ${exitCode}.`, exitCode);
+      throw new TestCloudError(`Cannot prepare UI Test artifacts. Returning exit code ${exitCode}.`, exitCode);
     }
 
     return path.join(this.artifactsDir, "manifest.json");

--- a/src/commands/test/lib/uitest-preparer.ts
+++ b/src/commands/test/lib/uitest-preparer.ts
@@ -44,7 +44,7 @@ export class UITestPreparer {
     let exitCode = await process.execAndWait(command);
 
     if (exitCode !== 0) {
-      throw new TestCloudError("Cannot prepare UI Test artifacts. Please inspect logs for more details", exitCode);
+      throw new TestCloudError(`cannot prepare UI Test artifacts. Returning exit code ${exitCode}.`, exitCode);
     }
 
     return path.join(this.artifactsDir, "manifest.json");

--- a/src/commands/test/lib/xcuitest-preparer.ts
+++ b/src/commands/test/lib/xcuitest-preparer.ts
@@ -67,10 +67,10 @@ export class XCUITestPreparer {
   private async generateTestIpa(): Promise<void> {
     let runnerAppPaths = await pglob.glob(path.join(this.buildDir, "*-Runner.app"));
     if (runnerAppPaths.length == 0) {
-      throw new TestCloudError(`unable to find test runner app within ${this.buildDir}`);
+      throw new TestCloudError(`Unable to find test runner app within ${this.buildDir}`);
     }
     if (runnerAppPaths.length > 1) {
-      throw new TestCloudError(`multiple test runner apps found within ${this.buildDir}`);
+      throw new TestCloudError(`Multiple test runner apps found within ${this.buildDir}`);
     }
     this.testIpaPath = path.join(this.artifactsDir, `${path.parse(runnerAppPaths[0]).name}.ipa`);
     await iba.archiveAppBundle(runnerAppPaths[0], this.testIpaPath);

--- a/src/commands/test/lib/xcuitest-preparer.ts
+++ b/src/commands/test/lib/xcuitest-preparer.ts
@@ -67,10 +67,10 @@ export class XCUITestPreparer {
   private async generateTestIpa(): Promise<void> {
     let runnerAppPaths = await pglob.glob(path.join(this.buildDir, "*-Runner.app"));
     if (runnerAppPaths.length == 0) {
-      throw new TestCloudError(`Unable to find test runner app within ${this.buildDir}`);
+      throw new TestCloudError(`unable to find test runner app within ${this.buildDir}`);
     }
     if (runnerAppPaths.length > 1) {
-      throw new TestCloudError(`Multiple test runner apps found within ${this.buildDir}`);
+      throw new TestCloudError(`multiple test runner apps found within ${this.buildDir}`);
     }
     this.testIpaPath = path.join(this.artifactsDir, `${path.parse(runnerAppPaths[0]).name}.ipa`);
     await iba.archiveAppBundle(runnerAppPaths[0], this.testIpaPath);

--- a/src/commands/test/run/xcuitest.ts
+++ b/src/commands/test/run/xcuitest.ts
@@ -59,10 +59,10 @@ export default class RunXCUITestCommand extends RunTestsCommand {
     );
 
     if (appPaths.length == 0) {
-      throw new TestCloudError(`Unable to find app within ${this.buildDir}`);
+      throw new TestCloudError(`unable to find app within ${this.buildDir}`);
     }
     if (appPaths.length > 1) {
-      throw new TestCloudError(`Multiple apps found within ${this.buildDir}`);
+      throw new TestCloudError(`multiple apps found within ${this.buildDir}`);
     }
 
     this.appPath = path.join((await this.getArtifactsDir()), `${path.parse(appPaths[0]).name}.ipa`);

--- a/src/commands/test/status.ts
+++ b/src/commands/test/status.ts
@@ -31,7 +31,7 @@ export default class StatusCommand extends AppCommand {
       return success();
     }
     else {
-      return failure(exitCode, "Test run failed. Please inspect logs for more details");
+      return failure(exitCode, `Test run failed. Returning exit code ${exitCode}.`);
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ let runner = commandRunner(path.join(__dirname, "commands"));
 runner(process.argv.slice(2))
   .then((result: CommandResult) => {
     if (failed(result)) {
-      console.log(`Command failed, ${result.errorMessage}`);
+      console.log(`Command failed: ${result.errorMessage}`);
       process.exit(result.errorCode);
     }
   });

--- a/src/util/misc/ios-bundle-archiver.ts
+++ b/src/util/misc/ios-bundle-archiver.ts
@@ -17,13 +17,13 @@ export async function archiveAppBundle(appPath: string, ipaPath: string): Promis
     let exitCode = await process.execAndWait(`ditto ${appPath} ${tempAppPath}`);
     if (exitCode !== 0) {
       await pfs.rmDir(tempPath, true);
-      throw new Error("Cannot archive app bundle. Please inspect logs for more details");
+      throw new Error("Cannot archive app bundle.");
     }
     
     exitCode = await process.execAndWait(`ditto -ck --sequesterRsrc ${tempPath} ${ipaPath}`);
     if (exitCode !== 0) {
       await pfs.rmDir(tempPath, true);
-      throw new Error("Cannot archive app bundle. Please inspect logs for more details");
+      throw new Error("Cannot archive app bundle.");
     }
 
     await pfs.rmDir(tempPath, true);


### PR DESCRIPTION
This PR contains two changes:
1. It adds `timeout` argument to all Test Cloud `run` commands. That will allow us to limit the time that we spend waiting for test completion, and is needed for Build - Test integration.
2. Improves messages. 
Many of our users complaint that the message "please inspect logs for more details" is confusing - there are no logs. This message is now removed; instead, the code prints exit code, what can be helpful during automation.

## Sample output for `run` command with `timeout`
```
...
Current test status: Validating
Current test status: Validation completed. Waiting for devices
After 30 seconds, command timed out waiting for tests to finish.
Command failed: cannot run Test Cloud tests. Returning exit code 64.
```