### PR TITLE
Implemented .xcarchive support for 'build download' command

### DIFF
--- a/src/util/misc/jszip-helper.ts
+++ b/src/util/misc/jszip-helper.ts
@@ -1,20 +1,27 @@
 import * as JsZip from "jszip";
 import * as Path from "path";
 import * as Pfs from "./promisfied-fs";
-import * as mkdirp from "mkdirp";
 
 /**
  * Unpacks ZIP file contents to the specified folder (it should already exist)
+ * root parameter can be used to extract specific folder from the zip archive
  */
-export async function unpackZipToPath(path: string, zip: JSZip): Promise<void> {
-  let entries = zip.filter((relativePath, file) => !file.dir);
+export async function unpackZipToPath(path: string, zip: JSZip, root: string = ""): Promise<void> {
+  const entries = zip.filter((relativePath, file) => file.name.startsWith(root));
 
   for (const entry of entries){
-    // Creating directory path if needed    
-    mkdirp.sync(Path.join(path, Path.dirname(entry.name)));
-    
-    let buffer: Buffer = await entry.async("nodebuffer");
-    await Pfs.writeFile(Path.join(path, entry.name), buffer);
+    const zipPath = entry.name.substring(root.length);
+
+    if (entry.dir) {
+      await Pfs.mkdirp(Path.join(path, zipPath));
+    } else {
+      const fileDirPath = Path.join(path, Path.dirname(zipPath));
+      // Creating directory path if needed    
+      await Pfs.mkdirp(fileDirPath);
+
+      let buffer: Buffer = await entry.async("nodebuffer");
+      await Pfs.writeFile(Path.join(fileDirPath, Path.basename(zipPath)), buffer);
+    }
   }
 }
 

--- a/src/util/misc/promisfied-fs.ts
+++ b/src/util/misc/promisfied-fs.ts
@@ -3,6 +3,7 @@ import * as path from "path";
 import * as _ from "lodash";
 import * as rimraf from "rimraf";
 import * as temp from "temp";
+import * as mkDirP from "mkdirp";
 
 export async function stat(path: string | Buffer): Promise<fs.Stats> {
   return (await callFs(fs.stat, path))[0];
@@ -57,6 +58,20 @@ export function exists(path: string | Buffer): Promise<boolean> {
 
 export function mkdir(path: string | Buffer): Promise<void> {
   return callFs(fs.mkdir, path).then(() => {});
+}
+
+export function mkdirp (path: string): Promise<string>;
+export function mkdirp (path: string, opts: mkDirP.Opts): Promise<string>;
+export function mkdirp (...args: any[]): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    mkDirP.apply(null, args.concat([(err: Error, made: string) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(made);
+      }
+    }]));    
+  });
 }
 
 export function mkTempDir(affixes: string): Promise<string> {


### PR DESCRIPTION
Unsigned iOS builds result in .xcarchive instead of .ipa now. I have added .xcarchive support to 'build download' command. The .xcarchive folder is renamed to follow the common name convention.