### PR TITLE
Fixes bug 4122: Remove `test-cloud.exe help {command}` from error messages

### DIFF
--- a/src/commands/test/lib/interaction.ts
+++ b/src/commands/test/lib/interaction.ts
@@ -1,14 +1,14 @@
 import { out } from "../../../util/interaction";
 
 export async function progressWithResult<T>(title: string, action: Promise<T>): Promise<T> {
-  let prefix = `${title}...`;
+  let prefix = `${title}... `;
   try {
     let result = await out.progress(prefix, action);
-    out.text(`${prefix} done.`);
+    out.text(`${prefix}done.`);
     return result;
   }
   catch (err) {
-    out.text(`${prefix} failed.`);
+    out.text(`${prefix}failed.`);
     throw err;
   }
 }

--- a/src/commands/test/lib/uitest-preparer.ts
+++ b/src/commands/test/lib/uitest-preparer.ts
@@ -4,6 +4,7 @@ import * as _ from "lodash";
 import * as os from "os";
 import * as path from "path";
 import * as process from "../../../util/misc/process-helper";
+import { out } from "../../../util/interaction";
 
 const debug = require("debug")("mobile-center-cli:commands:test:lib:uitest-preparer");
 const minimumVersion = [2, 0, 1];
@@ -41,7 +42,7 @@ export class UITestPreparer {
 
     let command = await this.getPrepareCommand();
     debug(`Executing command ${command}`);
-    let exitCode = await process.execAndWait(command);
+    let exitCode = await process.execAndWait(command, this.outMessage, this.outMessage);
 
     if (exitCode !== 0) {
       throw new TestCloudError(`Cannot prepare UI Test artifacts. Returning exit code ${exitCode}.`, exitCode);
@@ -141,5 +142,17 @@ export class UITestPreparer {
     }
 
     return true;
+  }
+
+
+  /*
+    the UITest preparer sometimes prints messages with it's own executable name, such as 
+    "Run 'test-cloud.exe help prepare' for more details". It's confusing for end users,
+    so wer are removing lines that contain the executable name.
+  */
+  private outMessage(line: string) {
+    if (line.indexOf("test-cloud.exe") === -1) {
+      out.text(line);
+    }
   }
 }


### PR DESCRIPTION
The Mobile Center CLI calls `test-cloud.exe` (directly or using Mono on Mac) to prepare UI Tests, and prints its messages to console output. We want to make that invisible to user, but right now the `test-cloud.exe` prints its own name in a few error messages.

This change finds lines with `test-cloud.exe` and removes them from Mobile Center CLI output.

Link to the bug: https://msmobilecenter.visualstudio.com/Test/_workitems?id=4122&_a=edit
