### PR TITLE
Implemented auto-completion support for categories, commands and options

### DIFF
--- a/bin/mobile-center.js
+++ b/bin/mobile-center.js
@@ -43,7 +43,13 @@ function runCli() {
 }
 
 if (ensureNodeVersion()) {
-  runCli();
+  if(process.argv.indexOf("--compgen") === -1) {
+    runCli();
+  } else {
+    // return autocomplete result and exit
+    var commandLine = require('../dist/util/commandline');
+    commandLine.executeAutoComplete();
+  }
 } else {
   process.exit(1);
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,6 +9,7 @@ const sourcemaps = require('gulp-sourcemaps');
 const ts = require('gulp-typescript');
 const util = require('util');
 const autorest = require('./scripts/autorest');
+const autocompleteTree = require('./scripts/autocomplete-tree');
 
 let tsProject = ts.createProject('tsconfig.json');
 
@@ -48,9 +49,17 @@ gulp.task('copy-generated-client', function () {
     .pipe(gulp.dest('dist/util/apis/generated'));
 });
 
-gulp.task('build', [ 'build-ts', 'copy-assets', 'copy-generated-client' ]);
+gulp.task('generate-autocomplete-tree', function () {
+  autocompleteTree.generateAndSave();
+});
 
-gulp.task('build-sourcemaps', [ 'build-ts-sourcemaps', 'copy-assets', 'copy-generated-client' ]);
+gulp.task('build', function(done) {
+  runSeq([ 'build-ts', 'copy-assets', 'copy-generated-client' ], 'generate-autocomplete-tree', done);
+});
+
+gulp.task('build-sourcemaps', function(done) {
+  runSeq([ 'build-ts-sourcemaps', 'copy-assets', 'copy-generated-client' ], 'generate-autocomplete-tree', done);
+});
 
 gulp.task('clean-sourcemaps', function (cb) {
   return gulp.src('dist/**/*.js.map')

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
     "ms-rest": "^1.15.0",
+    "omelette": "^0.4.0",
     "p-limit": "^1.0.0",
     "request": "^2.76.0",
     "rimraf": "^2.5.4",

--- a/scripts/autocomplete-tree.js
+++ b/scripts/autocomplete-tree.js
@@ -1,0 +1,82 @@
+const _ = require("lodash");
+const Fs = require("fs");
+const Path = require("path");
+const OptionDecorators = require("../dist/util/commandline/option-decorators");
+
+const rootPath = "dist";
+const commandsPath = Path.join(rootPath, "commands");
+const treeFile = "autocomplete-tree.json";
+const treeFilePath = Path.join(rootPath, treeFile);
+
+/**
+ * Generates autocomplete tree and saves it to file
+ */
+function generateAndSave() {
+  const treeObject = generateAutoCompleteTree(commandsPath);
+
+  // saving tree
+  Fs.writeFileSync(treeFilePath, JSON.stringify(treeObject), "utf8");
+}
+
+/** 
+ * Constructs autocomplete tree from FS structure
+ * @param {string} path 
+ * @param {object} treeObject
+ * @returns {object | string[]}
+ */
+function generateAutoCompleteTree(path) {
+  let dirEntries;
+  if (dirEntries = getDirEntriesOrNull(path)) {
+    // path points to directory (category)
+    const treeObject = {};
+    const filteredDirEntries = dirEntries.filter((entry) => entry !== "lib" && entry !== "category.txt" && Path.extname(entry) !== ".map");
+
+    filteredDirEntries.forEach((entry) => {
+      treeObject[Path.parse(entry).name] = generateAutoCompleteTree(Path.join(path, entry));
+    })
+
+    return treeObject;
+  } else {
+    // path points to file (command)
+    return getOptionsForCommand(path);
+  }
+}
+
+/**
+ * Returns directory content or null for files
+ * @param {string} path 
+ * @return {string[] | null}
+ */
+function getDirEntriesOrNull(path) {
+  try {
+    return Fs.readdirSync(path);
+  } catch (error) {
+    // return null for files
+    if (error.code === "ENOTDIR") {
+      return null;
+    } else {
+      throw error;
+    }
+  }
+}
+
+/**
+ * Returns options for the specified command
+ * @param {string} path 
+ * @returns {object[]}
+ */
+function getOptionsForCommand(path) {
+  const command = require(Path.resolve(path)).default;
+
+  // getting command options
+  const optionsDescriptionsObject = OptionDecorators.getOptionsDescription(command.prototype);
+  const optionsDescriptions = Object.keys(optionsDescriptionsObject).map((key) => optionsDescriptionsObject[key]);
+  return optionsDescriptions.map((option) => ({ 
+    short: option.shortName ? "-" + option.shortName : undefined,
+    long: option.longName ? "--" + option.longName : undefined
+  }));
+}
+
+module.exports = {
+  generateAndSave
+}

--- a/src/commands/setup-autocomplete.ts
+++ b/src/commands/setup-autocomplete.ts
@@ -1,0 +1,46 @@
+import { Command, CommandResult, help, success, name, position, ErrorCodes, failure, shortName, longName, hasArg } from "../util/commandline";
+import * as _ from "lodash";
+import * as Path from "path";
+import * as Pfs from "../util/misc/promisfied-fs";
+import * as mkdirp from "mkdirp";
+import { setupAutoCompleteForShell } from "../util/commandline/autocomplete";
+
+const debug = require("debug")("mobile-center-cli:commands:setup-autocomplete");
+import { inspect } from "util";
+
+@help("Setups autocompletion for the shell")
+export default class SetupAutoCompleteCommand extends Command {
+  private static readonly supportedShells = ["bash", "zsh", "fish"];
+
+  @help("Shell to generate autocompletion code for. Supported values - bash, zsh, fish. Default: current shell")
+  @shortName("s")
+  @longName("shell")
+  @hasArg
+  shell: string;
+
+  @help("Optional shell profile path. Default: $HOME/.bash_profile for bash, $HOME/.zshrc for zsh, $HOME/.config/fish/config.fish for fish")
+  @name("shell-profile-path")
+  @position(0)
+  shellProfilePath: string;
+
+  async runNoClient(): Promise<CommandResult> {
+    if (_.isNil(this.shellProfilePath) && !_.isNil(this.shell)) {
+      return failure(ErrorCodes.InvalidParameter, "shell should be specified only when shell profile path is specified");
+    }
+
+    if (!_.isNil(this.shell) && SetupAutoCompleteCommand.supportedShells.indexOf(this.shell) === -1) {
+      return failure(ErrorCodes.InvalidParameter, `${this.shell} is not supported. Only ${SetupAutoCompleteCommand.supportedShells.join(", ")} are supported`);
+    }
+
+    if (_.isNil(this.shell) && (!process.env.SHELL || !process.env.SHELL.match(`/${SetupAutoCompleteCommand.supportedShells.join("|")}/`))) {
+      return failure(ErrorCodes.InvalidParameter, "current shell cannot be detected, please specify it explicitly");
+    }
+
+    if (!_.isNil(this.shellProfilePath)) {
+      mkdirp.sync(Path.dirname(this.shellProfilePath));
+    }
+
+    setupAutoCompleteForShell(this.shellProfilePath, this.shell);
+    // Omelette exits process, no need to return command result
+  }
+}

--- a/src/util/commandline/autocomplete.ts
+++ b/src/util/commandline/autocomplete.ts
@@ -1,0 +1,126 @@
+import * as _ from "lodash";
+import * as Path from "path";
+import * as Fs from "fs";
+import * as OptionDecorators from "./option-decorators";
+
+const omelette = require("omelette");
+
+const appName = "mobile-center";
+const helpCommand = "help";
+const helpCommandFile = helpCommand + ".js";
+
+function getAutoCompleteObject() {
+  return omelette(appName);
+}
+
+export function executeAutoComplete() {
+  const autoCompleteObject = getAutoCompleteObject();
+  autoCompleteObject.on("complete", function (fragment: string, data: { before: string, fragment: number, line: string, reply: (answer: any) => void }) {
+    const line = data.line;
+    const reply = data.reply;
+    const argsLine = line.substring(appName.length);
+    const args = argsLine.match(/\S+/g) || [];
+    const rootPath = Path.normalize(Path.join(__dirname, "..", "..", "commands"));
+    const lineEndsWithWhitespaceChar = /\s{1}/.test(_.last(line));
+    const helpMode = _.head(args) === helpCommand;
+    const pathToHelpCommand = Path.join(rootPath, helpCommandFile);
+    const getReply = getReplyHandler(lineEndsWithWhitespaceChar, helpMode, pathToHelpCommand);
+
+    reply(getReply(helpMode ? _.tail(args) : args, rootPath));
+  });  
+  
+  autoCompleteObject.init();
+}
+
+export function setupAutoCompleteForShell(path?: string, shell?: string): any {
+  const autoCompleteObject = getAutoCompleteObject();
+  if (shell) {
+    autoCompleteObject.shell = shell;
+  } else {
+    autoCompleteObject.shell = autoCompleteObject.getActiveShell();
+  }
+
+  autoCompleteObject.setupShellInitFile(path);
+}
+
+function getReplyHandler(lineEndsWithWhitespaceChar: boolean, helpMode: boolean, pathToHelpCommand: string): (args: string[], path: string) => string[] {
+  return function getReply(args: string[], path: string): string[] {
+    const currentArg = _.head(args);
+    const currentDirEntities = Fs.readdirSync(path).filter((entry) => entry !== "lib" && entry !== "category.txt" && Path.extname(entry) !== ".map" && (!helpMode || entry !== helpCommandFile));
+    const commandsAndCategoriesToEntities = new Map<string, string>(currentDirEntities.map((entity) => <[string, string]> [Path.parse(entity).name, entity]));
+
+    if (_.isUndefined(currentArg)) {
+      // no more args - show all of the items at the current level
+      return Array.from(commandsAndCategoriesToEntities.keys());
+    } else {
+      // check what arg points to
+      const entity = commandsAndCategoriesToEntities.get(currentArg);
+      if (entity) {
+        // arg points to an existing command or category
+        const pathToEntity = Path.join(path, entity);
+        const restOfArgs = _.tail(args);
+        if (restOfArgs.length || lineEndsWithWhitespaceChar) {
+          if (Path.extname(entity)) {
+            // it is command
+            const getCommandReply = getCommandReplyHandler(lineEndsWithWhitespaceChar);
+            return getCommandReply(restOfArgs, getOptionNames(pathToEntity, helpMode, pathToHelpCommand));
+          } else {
+            // it is category
+            return getReply(restOfArgs, pathToEntity);
+          }
+        } else {
+          // if last arg has no trailing whitespace, it should be added
+          return [currentArg];
+        }
+      } else {
+        // arg points to nothing specific - return commands and categories which start with arg
+        return Array.from(commandsAndCategoriesToEntities.keys()).filter((commandOrCategory) => commandOrCategory.startsWith(currentArg));
+      }
+    }
+  };
+}
+
+function getCommandReplyHandler(lineEndsWithWhitespaceChar: boolean): (args: string[], optionNames: IOptionNames[]) => string[] {
+  return function getCommandReply(args: string[], optionsNames: IOptionNames[]): string[] {  
+    const currentArg = _.head(args);
+    if (_.isUndefined(currentArg)) {
+      // no more args, returning remaining optionsNames
+      return optionsNames.map((option) => option.long || option.short);
+    } else {
+      const restOfArgs = _.tail(args);
+      if (restOfArgs.length || lineEndsWithWhitespaceChar) {
+        const filteredOptions = optionsNames.filter((option) => option.long !== currentArg && option.short !== currentArg);
+        return getCommandReply(restOfArgs, filteredOptions);
+      } else {
+        const candidates: string[] = [];
+        for (const option of optionsNames) {
+          if (option.long && option.long.startsWith(currentArg)) {
+            candidates.push(option.long);
+          } else if (option.short && option.short.startsWith(currentArg)) {
+            candidates.push(option.short);
+          }
+        }
+        return candidates;
+      }
+    }
+  }
+}
+
+interface IOptionNames {
+  short: string;
+  long: string;
+}
+
+function getOptionNames(pathToCommand: string, helpMode: boolean, pathToHelpCommand: string): IOptionNames[] {
+  // loading command class
+  // if help mode ("help" command is invoked), options for "help" command should be shown
+  const command = require(helpMode ? pathToHelpCommand : pathToCommand).default;
+
+  // getting command options
+  const optionsDescriptionsObject = OptionDecorators.getOptionsDescription(command.prototype);
+  const optionsDescriptions = Object.keys(optionsDescriptionsObject).map((key) => optionsDescriptionsObject[key]);
+  return optionsDescriptions.map((option) => ({ 
+    short: option.shortName ? "-" + option.shortName : null,
+    long: option.longName ? "--" + option.longName : null
+  }));
+}

--- a/src/util/commandline/index.ts
+++ b/src/util/commandline/index.ts
@@ -3,3 +3,4 @@ export { AppCommand, getCurrentApp } from "./app-command";
 export { shortName, longName, hasArg, position, name, required, defaultValue, help } from "./option-decorators";
 export { runner } from "./command-runner";
 export * from "./command-result";
+export * from "./autocomplete";


### PR DESCRIPTION
Implemented auto-completion for categories, commands and options using [Omelette](https://www.npmjs.com/package/omelette).
![autocomplete](https://cloud.githubusercontent.com/assets/25530829/25922218/fa9cf5e6-35e0-11e7-9f6a-dc015484fd3a.png)

Auto-completion script can be installed using "setup-autocomplete" command. Bash, zsh and fish shells are supported.
![setup-autocomplete](https://cloud.githubusercontent.com/assets/25530829/25922318/6dbff0be-35e1-11e7-8cb3-2d5ed3fa98c0.PNG)

Terminal should be restarted afterwards for the changes to take effect.
