### PR TITLE
fix regexp

### DIFF
--- a/src/commands/test/run/xcuitest.ts
+++ b/src/commands/test/run/xcuitest.ts
@@ -55,7 +55,7 @@ export default class RunXCUITestCommand extends RunTestsCommand {
 
   private async generateAppIpa(): Promise<void> {
     let appPaths = (await pfs.readdir(this.buildDir)).filter(
-      (appPath) => /[^-Runner].app$/.test(appPath)
+      (appPath) => /^(?:.(?!-Runner\.app))+\.app$/.test(appPath)
     );
 
     if (appPaths.length == 0) {


### PR DESCRIPTION
When uploading xcuitests the app dir is matched with: ^*[^-Runner].app$

[^ does not work the way the author intended with the result of any app with R,u,n,e,r characters in their name will fail to be matched. (and . is problematic too) This change fixes the regexp.