### PR TITLE
Fix for customer reported error when spaces in --build-dir.

### DIFF
--- a/src/commands/test/lib/uitest-preparer.ts
+++ b/src/commands/test/lib/uitest-preparer.ts
@@ -83,7 +83,11 @@ export class UITestPreparer {
 
   private async getTestCloudExecutablePath(): Promise<string> {
     let toolsDir = this.uiTestToolsDir || await this.findXamarinUITestNugetDir(this.buildDir);
-    return path.join(toolsDir, "test-cloud.exe");
+    let testCloudPath = path.join(toolsDir, "test-cloud.exe");
+    if (testCloudPath.includes(" ")) {
+      testCloudPath = `"${testCloudPath}"`;
+    }
+    return testCloudPath;
   }
 
   private async findXamarinUITestNugetDir(root: string): Promise<string> {
@@ -146,7 +150,7 @@ export class UITestPreparer {
 
 
   /*
-    the UITest preparer sometimes prints messages with it's own executable name, such as 
+    the UITest preparer sometimes prints messages with it's own executable name, such as
     "Run 'test-cloud.exe help prepare' for more details". It's confusing for end users,
     so wer are removing lines that contain the executable name.
   */


### PR DESCRIPTION
User ran:

```mobile-center test run uitest --app "owner/appname"
--devices "owner/device" --app-path "c:\path\with spaces\app.apk"
--test-series "master" --locale "en_US" --build-dir
"C:\Users\users\documents\visual studio 2015\projects\etc"
```
And got:

```
Preparing tests... 'C:\Users\user\documents\visual' is not recognized
as an internal or external command, operable program or batch file.
```

Code was missing an extra layer of quotes in path if there's a space
before shelling out to the test preparer command.
