### PR TITLE
Updated help messages for time range parameters

### DIFF
--- a/src/commands/analytics/app-versions.ts
+++ b/src/commands/analytics/app-versions.ts
@@ -9,18 +9,19 @@ import * as Pfs from "../../util/misc/promisfied-fs";
 import { DefaultApp } from "../../util/profile";
 import * as Os from "os";
 import { parseDate } from "./lib/date-parsing-helper";
+import { startDateHelpMessage, endDateHelpMessage } from "./lib/analytics-constants";
 
 const debug = require("debug")("mobile-center-cli:commands:analytics:app-versions");
 
 @help("Shows versions of the application")
 export default class ShowAppVersionsCommand extends AppCommand {
-  @help("Start date (e.g. '1970/01/01 00:00' (system time zone), RFC2822 and ISO 8601 date strings are also supported)")
+  @help(startDateHelpMessage)
   @shortName("s")
   @longName("start")
   @hasArg
   public startDate: string;
 
-  @help("End date (e.g. '1970/01/01 00:00' (system time zone), RFC2822 and ISO 8601 date strings are also supported)")
+  @help(endDateHelpMessage)
   @shortName("e")
   @longName("end")
   @hasArg

--- a/src/commands/analytics/audience.ts
+++ b/src/commands/analytics/audience.ts
@@ -5,6 +5,7 @@ import { inspect } from "util";
 import * as _ from "lodash";
 import { DefaultApp } from "../../util/profile";
 import { parseDate } from "./lib/date-parsing-helper";
+import { startDateHelpMessage, endDateHelpMessage } from "./lib/analytics-constants";
 
 const debug = require("debug")("mobile-center-cli:commands:analytics:audience");
 
@@ -16,13 +17,13 @@ export default class AudienceCommand extends AppCommand {
     supportsCsv(this.additionalSupportedOutputFormats);
   }
 
-  @help("Start date (e.g. '1970/01/01 00:00' (system time zone), RFC2822 and ISO 8601 date strings are also supported)")
+  @help(startDateHelpMessage)
   @shortName("s")
   @longName("start")
   @hasArg
   public startDate: string;
 
-  @help("End date (e.g. '1970/01/01 00:00' (system time zone), RFC2822 and ISO 8601 date strings are also supported)")
+  @help(endDateHelpMessage)
   @shortName("e")
   @longName("end")
   @hasArg

--- a/src/commands/analytics/events/show.ts
+++ b/src/commands/analytics/events/show.ts
@@ -6,6 +6,7 @@ import * as _ from "lodash";
 import { DefaultApp } from "../../../util/profile";
 import { parseDate } from "../lib/date-parsing-helper";
 import { calculatePercentChange } from "../lib/percent-change-helper";
+import { startDateHelpMessage, endDateHelpMessage } from "../lib/analytics-constants";
 
 const debug = require("debug")("mobile-center-cli:commands:analytics:events:show");
 const pLimit = require("p-limit");
@@ -24,13 +25,13 @@ export default class ShowCommand extends AppCommand {
   @longName("properties")
   public properties: boolean;
 
-  @help("Start date (e.g. '1970/01/01 00:00' (system time zone), RFC2822 and ISO 8601 date strings are also supported)")
+  @help(startDateHelpMessage)
   @shortName("s")
   @longName("start")
   @hasArg
   public startDate: string;
 
-  @help("End date (e.g. '1970/01/01 00:00' (system time zone), RFC2822 and ISO 8601 date strings are also supported)")
+  @help(endDateHelpMessage)
   @shortName("e")
   @longName("end")
   @hasArg

--- a/src/commands/analytics/lib/analytics-constants.ts
+++ b/src/commands/analytics/lib/analytics-constants.ts
@@ -1,0 +1,3 @@
+export const startDateHelpMessage = "Start date (e.g. '1970/01/01 00:00' (system time zone), RFC2822 and ISO 8601 date strings are also supported). Default value: the beginning of current UTC day";
+
+export const endDateHelpMessage = "End date (e.g. '1970/01/01 00:00' (system time zone), RFC2822 and ISO 8601 date strings are also supported). Default value: now";

--- a/src/commands/analytics/sessions.ts
+++ b/src/commands/analytics/sessions.ts
@@ -6,6 +6,7 @@ import * as _ from "lodash";
 import { DefaultApp } from "../../util/profile";
 import { parseDate } from "./lib/date-parsing-helper";
 import { calculatePercentChange } from "./lib/percent-change-helper";
+import { startDateHelpMessage, endDateHelpMessage } from "./lib/analytics-constants";
 
 const debug = require("debug")("mobile-center-cli:commands:analytics:sessions");
 const IsoDuration = require("iso8601-duration");
@@ -18,13 +19,13 @@ export default class SessionCommand extends AppCommand {
     supportsCsv(this.additionalSupportedOutputFormats);
   }
 
-  @help("Start date (e.g. '1970/01/01 00:00' (system time zone), RFC2822 and ISO 8601 date strings are also supported)")
+  @help(startDateHelpMessage)
   @shortName("s")
   @longName("start")
   @hasArg
   public startDate: string;
 
-  @help("End date (e.g. '1970/01/01 00:00' (system time zone), RFC2822 and ISO 8601 date strings are also supported)")
+  @help(endDateHelpMessage)
   @shortName("e")
   @longName("end")
   @hasArg


### PR DESCRIPTION
Updated help messages of "analytics" commands with the time range parameters to contain default values of these parameters

Fix for #199 