### PR TITLE
Fixed issue with extra commas in CSV output of "analytics" commands

### DIFF
--- a/src/commands/analytics/audience.ts
+++ b/src/commands/analytics/audience.ts
@@ -180,7 +180,6 @@ export default class AudienceCommand extends AppCommand {
   }
 
   private outputStatistics(statisticsObject: IStatisticsObject): void {
-    const maximumNumberOfColumnsInTables = 4;
     out.reportObjectAsTitledTables((stats: IStatisticsObject, numberFormatter, dateFormatter, percentageFormatter) => {
       const tableArray: out.NamedTables = [];
 
@@ -219,7 +218,7 @@ export default class AudienceCommand extends AppCommand {
       }
 
       return tableArray;
-    }, statisticsObject, maximumNumberOfColumnsInTables);
+    }, statisticsObject);
   }
 }
 

--- a/src/commands/analytics/events/show.ts
+++ b/src/commands/analytics/events/show.ts
@@ -168,7 +168,6 @@ export default class ShowCommand extends AppCommand {
   }
 
   private outputStatistics(statistics: IEventStatistics[]) {
-    const maximumNumberOfColumnsInTables = 7;
     out.reportObjectAsTitledTables((events, numberFormatter, dateFormatter, percentageFormatter) => {
       const table: out.NamedTables = [];
       const eventsTable: out.INamedTable = {
@@ -193,7 +192,7 @@ export default class ShowCommand extends AppCommand {
       }
 
       return table;
-    }, statistics, maximumNumberOfColumnsInTables);
+    }, statistics);
   }
 }
 

--- a/src/commands/analytics/sessions.ts
+++ b/src/commands/analytics/sessions.ts
@@ -159,7 +159,6 @@ export default class SessionCommand extends AppCommand {
   }
 
   private outputStatistics(statisticsObject: IJsonOutput): void {
-    const maximumNumberOfColumnsInTables = 3;
     out.reportObjectAsTitledTables((stats: IJsonOutput, numberFormatter, dateFormatter, percentageFormatter) => {
       const tableArray: out.NamedTables = [];
 
@@ -182,7 +181,7 @@ export default class SessionCommand extends AppCommand {
       }
 
       return tableArray;
-    }, statisticsObject, maximumNumberOfColumnsInTables);
+    }, statisticsObject);
   }
 }
 

--- a/src/util/interaction/out.ts
+++ b/src/util/interaction/out.ts
@@ -535,6 +535,20 @@ function padTableCells(table: INamedTable): INamedTable {
   };
 }
 
+function calculateNumberOfColumns(tables: Array<INamedTable | string[]>): number {
+  if (tables.length) {
+    return _.max(tables.map((table) => {
+      if (table instanceof Array) {
+        return table.length || 1;
+      } else {
+        return calculateNumberOfColumns(table.content);
+      }
+    }));
+  } else {
+    return 1;
+  }
+}
+
 export interface INamedTable {
   name: string;
   content: Array<INamedTable | string[]>;
@@ -555,14 +569,14 @@ type ObjectToNamedTablesConvertor<T> = (object: T,
                                 percentageFormatter: (percentage: number) => string,
                               ) => NamedTables;
 
-export function reportObjectAsTitledTables<T>(toNamedTables: ObjectToNamedTablesConvertor<T>, object: T, columnsCount: number) {
+export function reportObjectAsTitledTables<T>(toNamedTables: ObjectToNamedTablesConvertor<T>, object: T) {
   if (formatIsJson()) {
     console.log(JSON.stringify(object));
   } else {
     let output: string;
     if (formatIsCsv()) {
       const stringTables = toNamedTables(object, (num) => num.toString(), (date) => date.toISOString(), (percentage) => percentage.toString());
-      output = convertNamedTablesToCsvString(stringTables, columnsCount);
+      output = convertNamedTablesToCsvString(stringTables, calculateNumberOfColumns(stringTables));
     } else {
       const stringTables = toNamedTables(object, (num) => _.round(num, 2).toString(), (date) => date.toString(), (percentage) => _.round(percentage, 2).toString() + "%");
       output = convertNamedTablesToListString(stringTables);


### PR DESCRIPTION
Fixed issue with extra commas in CSV output of "analytics" commands when some of the data tables are omitted.
![image](https://cloud.githubusercontent.com/assets/25530829/26704934/38b4c5a0-473b-11e7-9027-25c7bd9b4ecf.png)

Fixed #201 and #203 
