### PR TITLE
Cleaner API token description

### DIFF
--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -91,7 +91,7 @@ export default class LoginCommand extends Command {
     const client = this.clientFactory.fromUserNameAndPassword(this.userName, this.password, endpoint);
 
     let createTokenResponse = await out.progress("Logging in...",
-      clientRequest<models.ApiTokensCreateResponse>(cb => client.apiTokens.newMethod({ description: "Created from mobile center cli"}, cb)));
+      clientRequest<models.ApiTokensCreateResponse>(cb => client.apiTokens.newMethod({ description: "Mobile Center CLI"}, cb)));
 
     if (createTokenResponse.response.statusCode >= 400) {
       throw new Error("login was not successful");


### PR DESCRIPTION
"Created from mobile center cli" has some typos (product name isn't capitalized, nor is acronym 'CLI').

![image](https://user-images.githubusercontent.com/108197/27239671-c3651672-5286-11e7-8276-ff1d9f43a5d5.png)
