### PR TITLE
Access token and environment name can now be set with environment vars

### DIFF
--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -5,7 +5,7 @@ const opener = require("opener");
 import * as qs from "qs";
 
 import { Command, CommandArgs, CommandResult, success, failure, succeeded, ErrorCodes, help, shortName, longName, hasArg } from "../util/commandline";
-import { environments, defaultEnvironmentName, getUser, saveUser, deleteUser } from "../util/profile";
+import { environments, defaultEnvironmentName, getUser, saveUser, deleteUser, getTokenFromEnvironmentVar, mobileCenterAccessTokenEnvVar } from "../util/profile";
 import { prompt, out } from "../util/interaction";
 import { models, createMobileCenterClient, clientRequest, ClientResponse } from "../util/apis";
 import { TokenValueType } from "../util/token-store";
@@ -72,10 +72,13 @@ export default class LoginCommand extends Command {
 
   private validateArguments(): CommandResult {
     if (this.isInteractiveEnvironment && (this.userName || this.password) && !this.token) {
-      return failure(ErrorCodes.InvalidParameter, "This environment requires interactive login, do not use the --user or --password switches");
+      return failure(ErrorCodes.InvalidParameter, "this environment requires interactive login, do not use the --user or --password switches");
     }
     if (!this.isInteractiveEnvironment && (this.userName || this.password) && this.token) {
-      return failure(ErrorCodes.InvalidParameter, "You must specify either a token or a user/password, not both");
+      return failure(ErrorCodes.InvalidParameter, "you must specify either a token or a user/password, not both");
+    }
+    if (getTokenFromEnvironmentVar()) {
+      return failure(ErrorCodes.IllegalCommand, `can't login when token is set in environment variable ${mobileCenterAccessTokenEnvVar}`);
     }
     return success();
   }

--- a/src/util/profile/environment-vars.ts
+++ b/src/util/profile/environment-vars.ts
@@ -1,0 +1,12 @@
+import * as process from "process";
+import { defaultEnvironmentName } from "./environments";
+
+export const mobileCenterAccessTokenEnvVar = "MOBILE_CENTER_ACCESS_TOKEN";
+
+export function getTokenFromEnvironmentVar(): string {
+  return process.env[mobileCenterAccessTokenEnvVar];
+}
+
+export function getEnvFromEnvironmentVar(): string {
+  return process.env["MOBILE_CENTER_ENV"] || defaultEnvironmentName();
+}

--- a/src/util/profile/index.ts
+++ b/src/util/profile/index.ts
@@ -1,3 +1,4 @@
 export { environments, defaultEnvironmentName, EnvironmentInfo, getPortalUrlForEndpoint } from "./environments";
 export * from "./profile";
 export { telemetryIsEnabled, saveTelemetryOption } from "./telemetry";
+export * from "./environment-vars";


### PR DESCRIPTION
The app now checks if MOBILE_CENTER_ACCESS_TOKEN environment variable is set. If it is set, it's value will be used as token. MOBILE_CENTER_ENV environment variable may be optionally set to specify environment ("prod" by default). Please note that "mobile-center login" command is not allowed when MOBILE_CENTER_ACCESS_TOKEN is set.