### PR TITLE
Progress spinner is now shown during the whole logout process

### DIFF
--- a/src/commands/lib/logout.ts
+++ b/src/commands/lib/logout.ts
@@ -8,12 +8,15 @@ const debug = require("debug")("mobile-center-cli:commands:lib:logout");
 const maxTokenDeletionTimeoutSec = 10;
 
 export async function logout(client: MobileCenterClient, user: Profile): Promise<void> {
+  await out.progress("Logging out current user...", performLogout(client, user));
+}
+
+async function performLogout(client: MobileCenterClient, user: Profile): Promise<void> { 
   // Only delete token off the server if CLI created it.
   if (!user.tokenSuppliedByUser) {
     let tokenId: string;
     try {
-      await out.progress("Logging out current user...",
-        Promise.race([
+      await Promise.race([
           clientRequest(async cb => {
             try {
               tokenId = await user.accessTokenId;
@@ -31,8 +34,7 @@ export async function logout(client: MobileCenterClient, user: Profile): Promise
             // TODO: Investigate if there's a way to explicitly cancel the outstanding call.
             resolve();
           }, maxTokenDeletionTimeoutSec * 1000))
-        ])
-      );
+        ]);
     } catch (err) {
       // Noop, it's ok if deletion fails
       debug(`Deletion of token id ${tokenId} from server failed, error ${err}`);

--- a/src/commands/logout.ts
+++ b/src/commands/logout.ts
@@ -2,6 +2,7 @@ import { Command, CommandArgs, CommandResult, help, success } from "../util/comm
 import { MobileCenterClient } from "../util/apis";
 import { getUser } from "../util/profile";
 import { logout } from "./lib/logout";
+import { out } from "../util/interaction";
 
 @help("Logout from Mobile Center")
 export default class LogoutCommand extends Command {
@@ -11,6 +12,9 @@ export default class LogoutCommand extends Command {
 
   async run(client: MobileCenterClient): Promise<CommandResult> {
     await logout(client, getUser());
-    return success();
+    out.text("Successfully logged out");
+    // Force early exit to avoid long standing delays if token deletion is slow
+    process.exit(0);
+    return success(); // unreachable code, but it is required to keep TS compiler happy
   }
 }


### PR DESCRIPTION
Updated "logout" command to make sure that the app doesn't always waits for 10 seconds before exiting