### PR TITLE
Clear error messages for "build" commands when they are run for app not configured for building

### DIFF
--- a/src/commands/build/branches/list.ts
+++ b/src/commands/build/branches/list.ts
@@ -26,8 +26,13 @@ export default class ShowBranchesListBuildStatusCommand extends AppCommand {
     const branchBuildsHttpResponseCode = branchesStatusesRequestResponse.response.statusCode;
 
     if (branchBuildsHttpResponseCode >= 400) {
-      debug(`Request failed - HTTP ${branchBuildsHttpResponseCode} ${branchesStatusesRequestResponse.response.statusMessage}`);
-      return failure(ErrorCodes.Exception, "failed to fetch branches list");
+      switch (branchBuildsHttpResponseCode) {
+        case 400: 
+          return failure(ErrorCodes.IllegalCommand, `app ${app.appName} is not configured for building`);
+        default:
+          debug(`Request failed - HTTP ${branchBuildsHttpResponseCode} ${branchesStatusesRequestResponse.response.statusMessage}`);
+          return failure(ErrorCodes.Exception, "failed to fetch branches list");
+      }
     }
 
     const branchesWithBuilds = _(branchesStatusesRequestResponse.result)

--- a/src/commands/build/branches/show.ts
+++ b/src/commands/build/branches/show.ts
@@ -26,8 +26,12 @@ export default class ShowBranchBuildStatusCommand extends AppCommand {
       branchBuildsRequestResponse = await out.progress(`Getting builds for branch ${this.branchName}...`, 
         clientRequest<models.Build[]>((cb) => client.builds.listByBranch(this.branchName, app.ownerName, app.appName, cb)));
     } catch (error) {
-      debug(`Request failed - ${inspect(error)}`);
-      return failure(ErrorCodes.Exception, "the Branch Builds request was rejected for an unknown reason");
+      if (error.statusCode === 400) {
+        return failure(ErrorCodes.IllegalCommand, `app ${app.appName} is not configured for building`);
+      } else {
+        debug(`Request failed - ${inspect(error)}`);
+        return failure(ErrorCodes.Exception, "the Branch Builds request was rejected for an unknown reason");
+      }
     }
 
     const builds = branchBuildsRequestResponse.result;

--- a/src/commands/build/download.ts
+++ b/src/commands/build/download.ts
@@ -153,8 +153,12 @@ export default class DownloadBuildStatusCommand extends AppCommand {
       buildStatusRequestResponse = await out.progress(`Getting status of build ${this.buildId}...`,
         clientRequest<models.Build>((cb) => client.builds.get(buildIdNumber, app.ownerName, app.appName, cb)));
     } catch (error) {
-      debug(`Request failed - ${inspect(error)}`);
-      throw failure(ErrorCodes.Exception, `failed to get status of build ${this.buildId}`);
+      if (error.statusCode === 404) {
+        throw failure(ErrorCodes.InvalidParameter, `build ${buildIdNumber} was not found`);
+      } else {
+        debug(`Request failed - ${inspect(error)}`);
+        throw failure(ErrorCodes.Exception, `failed to get status of build ${this.buildId}`);
+      }
     }
 
     const buildInfo = buildStatusRequestResponse.result;

--- a/src/commands/build/logs.ts
+++ b/src/commands/build/logs.ts
@@ -60,10 +60,13 @@ export default class DisplayLogsStatusCommand extends AppCommand {
         return await clientRequest<models.BuildLog>((cb) => client.builds.getLog(buildIdNumber, app.ownerName, app.appName, cb));
       } catch (error) {
         debug(`Request failed - ${inspect(error)}`);
-        if (error.statusCode === 401) {
-          throw failure(ErrorCodes.Exception, "failed to get build logs because the authentication has failed");
-        } else {
-          throw failure(ErrorCodes.Exception, "failed to get build logs");
+        switch (error.statusCode) {
+          case 401:
+            throw failure(ErrorCodes.Exception, "failed to get build logs because the authentication has failed");
+          case 404:
+            throw failure(ErrorCodes.InvalidParameter, `failed to get build logs because build ${buildIdNumber} doesn't exist`);
+          default:
+            throw failure(ErrorCodes.Exception, "failed to get build logs");
         }
       }
     }, (response, responsesProcessed) => {

--- a/src/commands/build/queue.ts
+++ b/src/commands/build/queue.ts
@@ -32,8 +32,12 @@ export default class QueueBuildCommand extends AppCommand {
           debug: this.debugLogs
         }, cb)));
     } catch (error) {
-      debug(`Request failed - ${inspect(error)}`);
-      return failure(ErrorCodes.Exception, "failed to queue build request");
+      if (error.statusCode === 400) {
+        return failure(ErrorCodes.IllegalCommand, `app ${app.appName} is not configured for building`);
+      } else {
+        debug(`Request failed - ${inspect(error)}`);
+        return failure(ErrorCodes.Exception, "failed to queue build request");
+      }
     }
 
     const buildId = queueBuildRequestResponse.result.id;


### PR DESCRIPTION
"build branches list", "build branches show", "build queue" commands show clear error message now when app is not configured for building;

"build logs", "build download" commands show "not found" error message instead (as API returns HTTP 404 when app is not configured for building);