### PR TITLE
Add 'mobile-center test stop' command for stopping the started test run.

### DIFF
--- a/src/commands/test/lib/help-messages.ts
+++ b/src/commands/test/lib/help-messages.ts
@@ -32,6 +32,7 @@ export module Messages {
       export const RunXCUITest = "Starts a test run with XCUITest tests.";
 
       export const Status = "Checks the status of the started test run.";
+      export const Stop = "Stop the started test run.";
     }
 
     export module Arguments {
@@ -69,6 +70,8 @@ export module Messages {
       export const UITestsKeyPassword = 'Password to the matching private key in the keystore. Corresponds to the "-keypass" argument in jarsigner';
       export const UITestsSignInfo = "Use Signing Info for signing the test server.";
       export const UITestsToolsDir = "Path to the directory containing the Xamarin UI Tests tools including test-cloud.exe";
+
+      export const StopTestRunId = "ID of the started test run";
 
       export const StatusTestRunId = "ID of the started test run";
       export const StatusContinuous = "Continuously checks the test run status until it completes";

--- a/src/commands/test/stop.ts
+++ b/src/commands/test/stop.ts
@@ -17,7 +17,7 @@ export default class StopCommand extends AppCommand {
 
   async run(client: MobileCenterClient): Promise<CommandResult> {
 
-    this.stopTestRun(client, this.testRunId);
+    await this.stopTestRun(client, this.testRunId);
 
     return success();
   }

--- a/src/commands/test/stop.ts
+++ b/src/commands/test/stop.ts
@@ -1,0 +1,35 @@
+import { AppCommand, CommandArgs, CommandResult,
+         help, success, longName, required, hasArg } from "../../util/commandline";
+import { MobileCenterClient, models, clientCall } from "../../util/apis";
+import { Messages } from "./lib/help-messages";
+
+@help(Messages.TestCloud.Commands.Stop)
+export default class StopCommand extends AppCommand {
+  @help(Messages.TestCloud.Arguments.StopTestRunId)
+  @longName("test-run-id")
+  @required
+  @hasArg
+  testRunId: string;
+
+  constructor(args: CommandArgs) {
+    super(args);
+  }
+
+  async run(client: MobileCenterClient): Promise<CommandResult> {
+
+    this.stopTestRun(client, this.testRunId);
+
+    return success();
+  }
+
+  private stopTestRun(client: MobileCenterClient, testRunId: string): Promise<VoidFunction> {
+    return clientCall(cb => {
+      client.test.stopTestRun(
+        testRunId,
+        this.app.ownerName,
+        this.app.appName,
+        cb
+      );
+    });
+  }
+}


### PR DESCRIPTION
The added command has been implemented in order to support Jenkins Plugin for Mobile Center Test.
Also, users will be able to cancel the testing process from the command line when they want.