### PR TITLE
codepush-deployment-add

### DIFF
--- a/src/commands/codepush/deployment/add.ts
+++ b/src/commands/codepush/deployment/add.ts
@@ -1,11 +1,9 @@
-import { AppCommand, CommandArgs, CommandResult, help, failure, ErrorCodes, success, getCurrentApp, shortName, longName, required, hasArg, position, name } from "../../../util/commandline";
+import { AppCommand, CommandArgs, CommandResult, help, failure, ErrorCodes, success, required, position, name } from "../../../util/commandline";
 import { out } from "../../../util/interaction";
-import { DefaultApp } from "../../../util/profile";
 import { inspect } from "util";
-import { MobileCenterClient, models, clientRequest, clientCall } from "../../../util/apis";
-const _ = require("lodash");
-const chalk = require("chalk");
-
+import { MobileCenterClient, models, clientRequest } from "../../../util/apis";
+import * as _ from "lodash";
+import * as chalk from "chalk";
 const debug = require("debug")("mobile-center-cli:commands:codepush:deployments:add");
 
 @help("Add a new deployment to an app")
@@ -29,18 +27,18 @@ export default class AddCommand extends AppCommand {
         (cb) => client.deployments.create(app.ownerName, app.appName, this.newDeploymentName, cb)));
       deployment = httpRequest.result;
       out.text(`Deployment ${deployment.name} has been created for the app ${app.appName}`);
-     return success();
+      return success();
     } catch (error) {
       debug(`Failed to add a new CodePush deployment - ${inspect(error)}`);
       if (error.statusCode === 404) {
         const appNotFoundErrorMsg = `The app ${app.ownerName}/${app.appName} does not exist. Please double check the name, and provide it in the form owner/appname. \nRun the command ${chalk.bold("mobile-center apps list")} to see what apps you have access to.`;
-        return failure(ErrorCodes.InvalidParameter, appNotFoundErrorMsg);
+        return failure(ErrorCodes.NotFound, appNotFoundErrorMsg);
       }
       else if (error.statusCode === 409) {
         const deploymentExistErrorMsg = `A deployment named ${chalk.bold(this.newDeploymentName)} already exists.`;
         return failure(ErrorCodes.Exception, deploymentExistErrorMsg);
       } else {
-        return failure(ErrorCodes.Exception, "failed to add a new CodePush deployment for the app");
+        return failure(ErrorCodes.Exception, error.message);
       }
     }
   }

--- a/src/commands/codepush/deployment/add.ts
+++ b/src/commands/codepush/deployment/add.ts
@@ -1,0 +1,47 @@
+import { AppCommand, CommandArgs, CommandResult, help, failure, ErrorCodes, success, getCurrentApp, shortName, longName, required, hasArg, position, name } from "../../../util/commandline";
+import { out } from "../../../util/interaction";
+import { DefaultApp } from "../../../util/profile";
+import { inspect } from "util";
+import { MobileCenterClient, models, clientRequest, clientCall } from "../../../util/apis";
+const _ = require("lodash");
+const chalk = require("chalk");
+
+const debug = require("debug")("mobile-center-cli:commands:codepush:deployments:add");
+
+@help("Add a new deployment to an app")
+export default class AddCommand extends AppCommand {
+
+  @help("New CodePush deployment name")
+  @required
+  @name("NewDeploymentName")
+  @position(0)
+  public newDeploymentName: string;
+
+  constructor(args: CommandArgs) {
+    super(args);
+  }
+
+  async run(client: MobileCenterClient): Promise<CommandResult> {
+    const app = this.app;
+    let deployment: models.Deployment;
+    try {
+      const httpRequest = await out.progress("Creating a new CodePush deployment...", clientRequest<models.Deployment>(
+        (cb) => client.deployments.create(app.ownerName, app.appName, this.newDeploymentName, cb)));
+      deployment = httpRequest.result;
+      out.text(`Deployment ${deployment.name} has been created for the app ${app.appName}`);
+     return success();
+    } catch (error) {
+      debug(`Failed to add a new CodePush deployment - ${inspect(error)}`);
+      if (error.statusCode === 404) {
+        const appNotFoundErrorMsg = `The app ${app.ownerName}/${app.appName} does not exist. Please double check the name, and provide it in the form owner/appname. \nRun the command ${chalk.bold("mobile-center apps list")} to see what apps you have access to.`;
+        return failure(ErrorCodes.InvalidParameter, appNotFoundErrorMsg);
+      }
+      else if (error.statusCode === 409) {
+        const deploymentExistErrorMsg = `A deployment named ${chalk.bold(this.newDeploymentName)} already exists.`;
+        return failure(ErrorCodes.Exception, deploymentExistErrorMsg);
+      } else {
+        return failure(ErrorCodes.Exception, "failed to add a new CodePush deployment for the app");
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR attempts to integrate `codepush deployment add` command into the mobile center as `mobile-center codepush deployment add`.