### PR TITLE
code-push-patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "typescript": "^2.4.2"
   },
   "dependencies": {
+    "@types/semver": "^5.3.33",
     "azure-storage": "^2.1.0",
     "bplist": "0.0.4",
     "chalk": "^1.1.3",
@@ -74,6 +75,7 @@
     "request": "^2.76.0",
     "rimraf": "^2.5.4",
     "rx-lite": "^4.0.8",
+    "semver": "^5.4.1",
     "temp": "^0.8.3",
     "uuid": "^3.0.1",
     "wordwrap": "^1.0.0"

--- a/src/commands/codepush/patch.ts
+++ b/src/commands/codepush/patch.ts
@@ -2,7 +2,6 @@ import { AppCommand, CommandArgs, CommandResult, help, failure, ErrorCodes, succ
 import { out } from "../../util/interaction";
 import { inspect } from "util";
 import { MobileCenterClient, models, clientRequest, clientCall } from "../../util/apis";
-import * as _ from "lodash";
 import * as chalk from "chalk";
 import * as semver from "semver";
 
@@ -62,14 +61,14 @@ export default class PatchCommand extends AppCommand {
       return failure(ErrorCodes.Exception, "At least one property must be specified to patch a release.");
     }
 
-    if (this.rollout != null && this.rollout !== undefined) {
-      if (parseInt(this.rollout) < 0 || parseInt(this.rollout) > 100 || !/^(100|[1-9][0-9]|[1-9])$/.test(this.rollout)) {
+    if (this.rollout != null) {
+      if (!/^(100|[1-9][0-9]|[1-9])$/.test(this.rollout)) {
         return failure(ErrorCodes.Exception, `Rollout value should be integer value between ${chalk.bold('0')} or ${chalk.bold('100')}.`);
       }
     }
 
     const isValidVersion = (version: string): boolean => !!semver.valid(version) || /^\d+\.\d+$/.test(version) || /^\d+$/.test(version);
-    if (this.targetBinaryRange !== null && this.targetBinaryRange !== undefined && !isValidVersion(this.targetBinaryRange)) {
+    if (this.targetBinaryRange != null && !isValidVersion(this.targetBinaryRange)) {
       return failure(ErrorCodes.Exception, "Invalid binary version(s) for a release.");
     }
 

--- a/src/commands/codepush/patch.ts
+++ b/src/commands/codepush/patch.ts
@@ -90,14 +90,24 @@ export default class PatchCommand extends AppCommand {
       return failure(ErrorCodes.Exception, "Invalid binary version(s) for a release.");      
     }
 
-    let patch: models.LiveUpdateReleaseModification = {
-      targetBinaryRange: this.targetBinaryRange,
-      isMandatory: this.isMandatory === 'true' || this.isMandatory === 'True',
-      isDisabled: this.isDisabled === 'true' || this.isDisabled === 'True',
-      description: this.description,
-      rollout: parseInt(this.rollout)
+    let patch: models.LiveUpdateReleaseModification;
+    if (this.rollout!=null) {
+      patch = {
+        targetBinaryRange: this.targetBinaryRange,
+        isMandatory: this.isMandatory === 'true' || this.isMandatory === 'True',
+        isDisabled: this.isDisabled === 'true' || this.isDisabled === 'True',
+        description: this.description,
+        rollout: parseInt(this.rollout)
+      }
+    } else {
+      patch = {
+        targetBinaryRange: this.targetBinaryRange,
+        isMandatory: this.isMandatory === 'true' || this.isMandatory === 'True',
+        isDisabled: this.isDisabled === 'true' || this.isDisabled === 'True',
+        description: this.description,
+      }
     }
-
+    
     try {
       const httpRequest = await out.progress("Patching CodePush release...", clientRequest<models.LiveUpdateRelease>(
         (cb) => client.deploymentReleases.update(this.deploymentName, this.releaseLabel, patch, app.ownerName, app.appName, cb)));

--- a/src/commands/codepush/patch.ts
+++ b/src/commands/codepush/patch.ts
@@ -1,0 +1,116 @@
+import { AppCommand, CommandArgs, CommandResult, help, failure, ErrorCodes, success, getCurrentApp, shortName, longName, required, hasArg, position, name } from "../../util/commandline";
+import { out } from "../../util/interaction";
+import { DefaultApp } from "../../util/profile";
+import { inspect } from "util";
+import { MobileCenterClient, models, clientRequest, clientCall } from "../../util/apis";
+const _ = require("lodash");
+const chalk = require("chalk");
+import * as semver from "semver";
+
+const debug = require("debug")("mobile-center-cli:commands:codepush:patch");
+
+@help("Update the metadata for an existing release")
+export default class PatchCommand extends AppCommand {
+  
+  @help("CodePush deployment name")
+  @required
+  @name("ExistingDeploymentName")
+  @position(0)
+  public deploymentName: string;
+
+  @help("CodePush release label")
+  @required
+  @name("ExistingReleaseLabel")
+  @position(1)
+  public releaseLabel: string;
+
+  @help("update whether the release should be considered mandatory or not")
+  @shortName("m")
+  @longName("mandatory")
+  @hasArg
+  public isMandatory: string;
+
+  @help("update the description associated with the release")
+  @shortName("x")
+  @longName("disabled")
+  @hasArg
+  public isDisabled: string;
+
+  @help("update the semver range that indicates which binary version(s) a release")
+  @shortName("t")
+  @longName("targetBinaryVersion")
+  @hasArg
+  public targetBinaryRange: string;
+
+  @help("update the description associated with the release")
+  @shortName("des")
+  @longName("description")
+  @hasArg
+  public description: string;
+
+  @help("allows you to increase the rollout percentage of the target release")
+  @shortName("r")
+  @longName("rollout")
+  @hasArg
+  public rollout: string;
+
+  constructor(args: CommandArgs) {
+    super(args);
+  }
+
+  async run(client: MobileCenterClient): Promise<CommandResult> {
+
+    const app = this.app;
+    let release: models.LiveUpdateRelease;
+
+    if (this.targetBinaryRange == null && this.isDisabled == null && this.isMandatory == null && this.description == null && this.rollout == null) {
+      return failure(ErrorCodes.Exception, "At least one property must be specified to patch a release.");
+    }
+
+    if (this.isMandatory != null) {
+      if (this.isMandatory != 'true' && this.isMandatory != 'false') {
+        return failure(ErrorCodes.Exception, `Mandatory value should be either ${chalk.bold(true)} or ${chalk.bold(false)}.`);  
+      }
+    }
+
+    if (this.isDisabled != null) {
+      if (this.isDisabled != 'true' && this.isDisabled != 'false') {
+        return failure(ErrorCodes.Exception, `Disabled value should be either ${chalk.bold(true)} or ${chalk.bold(false)}.`);  
+      }
+    }
+
+    if (this.rollout != null) {
+      if (parseInt(this.rollout) < 0 || parseInt(this.rollout) > 100) {
+        return failure(ErrorCodes.Exception, `Rollout value should be integer value between ${chalk.bold(0)} or ${chalk.bold(100)}.`);
+      }
+    }
+
+    const isValidVersion = (version: string): boolean => !!semver.valid(version) || /^\d+\.\d+$/.test(version);
+    if (this.targetBinaryRange != null && !isValidVersion(this.targetBinaryRange)) {
+      return failure(ErrorCodes.Exception, "Invalid binary version(s) for a release.");      
+    }
+
+    let patch: models.LiveUpdateReleaseModification = {
+      targetBinaryRange: this.targetBinaryRange,
+      isMandatory: this.isMandatory === 'true' || this.isMandatory === 'True',
+      isDisabled: this.isDisabled === 'true' || this.isDisabled === 'True',
+      description: this.description,
+      rollout: parseInt(this.rollout)
+    }
+
+    try {
+      const httpRequest = await out.progress("Patching CodePush release...", clientRequest<models.LiveUpdateRelease>(
+        (cb) => client.deploymentReleases.update(this.deploymentName, this.releaseLabel, patch, app.ownerName, app.appName, cb)));
+      release = httpRequest.result;
+      if (httpRequest.response.statusCode === 204) {
+        out.text(`No update for the ${chalk.bold(this.releaseLabel)} of ${chalk.bold(app.appName)} app's ${chalk.bold(this.deploymentName)} deployment`);
+      } else {
+        out.text(`Successfully updated the ${chalk.bold(release.label)} of ${chalk.bold(app.appName)} app's ${chalk.bold(this.deploymentName)} deployment`);
+      }
+      return success();
+    } catch (error) {
+      debug(`Failed to get list of Codepush deployments - ${inspect(error)}`);
+      return failure(ErrorCodes.Exception, error.response.body);
+    }
+  }
+}

--- a/src/commands/codepush/patch.ts
+++ b/src/commands/codepush/patch.ts
@@ -12,13 +12,13 @@ export default class PatchCommand extends AppCommand {
   
   @help("Specifies one existing deployment name.")
   @required
-  @name("--existing-deployment-name")
+  @name("existing-deployment-name")
   @position(0)
   public deploymentName: string;
 
   @help("Specifies label of one existing release to update. (Defaults to the latest release within the specified deployment)")
   @required
-  @name("--existing-release-label")
+  @name("existing-release-label")
   @position(1)
   public releaseLabel: string;
 

--- a/src/commands/codepush/patch.ts
+++ b/src/commands/codepush/patch.ts
@@ -7,42 +7,42 @@ import * as semver from "semver";
 
 const debug = require("debug")("mobile-center-cli:commands:codepush:patch");
 
-@help("Update the metadata for an existing release")
+@help("Update the metadata for an existing CodePush release")
 export default class PatchCommand extends AppCommand {
   
-  @help("CodePush deployment name.")
+  @help("Specifies one existing deployment name.")
   @required
-  @name("ExistingDeploymentName")
+  @name("--existing-deployment-name")
   @position(0)
   public deploymentName: string;
 
-  @help("Label of the release to update. Defaults to the latest release within the specified deployment.")
+  @help("Specifies label of one existing release to update. (Defaults to the latest release within the specified deployment)")
   @required
-  @name("ExistingReleaseLabel")
+  @name("--existing-release-label")
   @position(1)
   public releaseLabel: string;
 
-  @help("Specifies whether this release should be considered mandatory. Putting -m flag means mandatory.")
+  @help("Specifies whether this release should be considered mandatory. (Putting -m flag means mandatory)")
   @shortName("m")
   public isMandatory: boolean;
 
-  @help("Specifies whether this release should be immediately downloadable. Putting -x flag means disabled.")
+  @help("Specifies whether this release should be immediately downloadable. (Putting -x flag means disabled)")
   @shortName("x")
   public isDisabled: boolean;
 
-  @help("Semver expression that specifies the binary app version(s) this release is targeting (e.g. 1.1.0, ~1.2.3).")
+  @help("Specifies binary app version(s) that specifies this release is targeting for. (The value must be a semver expression such as 1.1.0, ~1.2.3)")
   @shortName("t")
-  @longName("targetBinaryVersion")
+  @longName("target-binary-version")
   @hasArg
   public targetBinaryRange: string;
 
-  @help("Description of the changes made to the app with this release.")
+  @help("Specifies description of the changes made to the app with this release.")
   @shortName("d")
   @longName("description")
   @hasArg
   public description: string;
 
-  @help("Percentage of users this release should be immediately available to. This attribute can only be increased from the current value.")
+  @help("Specifies percentage of users this release should be immediately available to. (The specified number must be an integer between 1 and 100)")
   @shortName("r")
   @longName("rollout")
   @hasArg


### PR DESCRIPTION
This PR migrates `codepush patch` into mobile center:

The original codepush patch command [illustration](https://github.com/Microsoft/code-push/tree/master/cli#patching-update-metadata).

The current version:
<img width="783" alt="screen shot 2017-08-08 at 3 33 38 pm" src="https://user-images.githubusercontent.com/174866/29098407-17d9b4be-7c54-11e7-9429-0320a2c39cca.png">
 