### PR TITLE
Test cloud feature complete plus minor bug fixes

### DIFF
--- a/src/commands/orgs/lib/org-users-helper.ts
+++ b/src/commands/orgs/lib/org-users-helper.ts
@@ -20,6 +20,30 @@ export async function getOrgUsers(client: MobileCenterClient, organization: stri
   }
 }
 
+export async function getOrgsNamesList(client: MobileCenterClient, debug: Function): Promise<IEntity[]> {
+  try {
+    const httpResponse = await clientRequest<models.OrganizationResponse[]>((cb) => client.organizations.list(cb));
+    if (httpResponse.response.statusCode < 400) {
+      return httpResponse.result.map((org) => ({
+        name: org.name,
+        displayName: org.displayName,
+        origin: org.origin
+      }));
+    } else {
+      throw httpResponse.response;
+    }
+  } catch (error) {
+    debug(`Failed to load list of organization for current user - ${inspect(error)}`);
+    throw failure(ErrorCodes.Exception, "failed to load list of organization for the user");
+  }
+}
+
 export function pickAdmins(users: models.OrganizationUserResponse[]): models.OrganizationUserResponse[] {
   return users.filter((user) => user.role === "admin");
+}
+
+interface IEntity {
+  name: string;
+  displayName: string;
+  origin: string;
 }

--- a/src/commands/orgs/lib/org-users-helper.ts
+++ b/src/commands/orgs/lib/org-users-helper.ts
@@ -2,6 +2,8 @@ import { MobileCenterClient, models, clientRequest, ClientResponse } from "../..
 import { failure, ErrorCodes } from "../../../util/commandline";
 import { inspect } from "util";
 
+const debug = require("debug")("mobile-center-cli:commands:orgs:lib:org-users-helper");
+
 export async function getOrgUsers(client: MobileCenterClient, organization: string, debug: Function): Promise<models.OrganizationUserResponse[]> {
   try {
     const httpResponse = await clientRequest<models.OrganizationUserResponse[]>((cb) => client.users.listForOrg(organization, cb));
@@ -20,7 +22,7 @@ export async function getOrgUsers(client: MobileCenterClient, organization: stri
   }
 }
 
-export async function getOrgsNamesList(client: MobileCenterClient, debug: Function): Promise<IEntity[]> {
+export async function getOrgsNamesList(client: MobileCenterClient): Promise<IEntity[]> {
   try {
     const httpResponse = await clientRequest<models.OrganizationResponse[]>((cb) => client.organizations.list(cb));
     if (httpResponse.response.statusCode < 400) {

--- a/src/commands/orgs/list.ts
+++ b/src/commands/orgs/list.ts
@@ -10,7 +10,7 @@ import { getOrgsNamesList } from "./lib/org-users-helper";
 export default class OrgListCommand extends Command {
   async run(client: MobileCenterClient): Promise<CommandResult> {
     // every user is a collaborator of it's own group and of zero or more external groups
-    const orgs = await out.progress("Loading list of organizations...", getOrgsNamesList(client, debug));
+    const orgs = await out.progress("Loading list of organizations...", getOrgsNamesList(client));
     const table = orgs.map((names) => [names.displayName, names.name, names.origin]);
 
     out.table(out.getCommandOutputTableOptions(["Display Name", "Name", "Origin"]), table);

--- a/src/commands/orgs/list.ts
+++ b/src/commands/orgs/list.ts
@@ -4,40 +4,17 @@ import { MobileCenterClient, models, clientRequest } from "../../util/apis";
 
 const debug = require("debug")("mobile-center-cli:commands:orgs:list");
 import { inspect } from "util";
+import { getOrgsNamesList } from "./lib/org-users-helper";
 
 @help("Lists organizations in which current user is collaborator")
 export default class OrgListCommand extends Command {
   async run(client: MobileCenterClient): Promise<CommandResult> {
     // every user is a collaborator of it's own group and of zero or more external groups
-    const orgs = await out.progress("Loading list of organizations...", this.getOrgsNamesList(client));
+    const orgs = await out.progress("Loading list of organizations...", getOrgsNamesList(client, debug));
     const table = orgs.map((names) => [names.displayName, names.name, names.origin]);
 
     out.table(out.getCommandOutputTableOptions(["Display Name", "Name", "Origin"]), table);
 
     return success();
   }
-
-  private async getOrgsNamesList(client: MobileCenterClient): Promise<IEntity[]> {
-    try {
-      const httpResponse = await clientRequest<models.OrganizationResponse[]>((cb) => client.organizations.list(cb));
-      if (httpResponse.response.statusCode < 400) {
-        return httpResponse.result.map((org) => ({
-          name: org.name,
-          displayName: org.displayName,
-          origin: org.origin
-        }));
-      } else {
-        throw httpResponse.response;
-      }
-    } catch (error) {
-      debug(`Failed to load list of organization for current user - ${inspect(error)}`);
-      throw failure(ErrorCodes.Exception, "failed to load list of organization for the user");
-    }
-  }
-}
-
-interface IEntity {
-  name: string;
-  displayName: string;
-  origin: string;
 }

--- a/src/commands/test/lib/calabash-preparer.ts
+++ b/src/commands/test/lib/calabash-preparer.ts
@@ -64,7 +64,7 @@ export class CalabashPreparer {
     }
 
     if (this.testParameters && this.testParameters.length > 0) {
-      command += ` --test-parameters ${this.generateTestParameterArgs()}`;
+      command += ` --test-params ${this.generateTestParameterArgs()}`;
     }
 
     return command;
@@ -77,7 +77,7 @@ export class CalabashPreparer {
       this.testParameters.forEach(p => {
         let parsedParameter = parseTestParameter(p);
         if (result != "") {
-          result += " ";
+          result += ",";
         }
         result += `${parsedParameter.key}:`;
         if (parsedParameter.value != null) {

--- a/src/commands/test/lib/espresso-preparer.ts
+++ b/src/commands/test/lib/espresso-preparer.ts
@@ -73,7 +73,7 @@ export class EspressoPreparer {
        throw new Error(`An apk with name matching "*androidTest.apk" was not found inside directory inside build directory "${this.buildDir}"`);
     }
     else if (files.length >= 2) {
-       throw new Error(`Multiple apks with name matching "*androidTest.apk" was found inside directory inside build directory "${this.buildDir}". A unique match is required.`);
+       throw new Error(`Multiple apks with name matching "*androidTest.apk" were found inside build directory "${this.buildDir}". A unique match is required.`);
     }
     else {
       let apkPath = files[files.length - 1];

--- a/src/commands/test/lib/help-messages.ts
+++ b/src/commands/test/lib/help-messages.ts
@@ -48,6 +48,12 @@ export module Messages {
       export const RunDSymDir = "Path to the directory with iOS symbol files";
       export const RunLocale = "The system locale for the test run. For example, en_US";
       export const RunLanguage = "Override the language (iOS only) for the test run";
+      export const Fixture = "NUnit fixture / namespace to run. If used with include / exclude the fixture filter is applied first (Can be used multiple times)";
+      export const IncludeCategory = "NUnit category to run. (Can be used multiple times)";
+      export const ExcludeCategory = "NUnit category to not run. (Can be used multiple times) (When include and/or fixture are combined with exclude, all tests with the included categories are run, except for those also marked with the excluded categories)";
+      export const NUnitXml = "Output NUnit xml report to target file";
+      export const TestChunk = "Run tests in parallel by method";
+      export const FixtureChunk = "Run tests in parallel by fixture";
       export const RunTestSeries = "Name of the test series";
       export const RunAsync = "Exit the command when tests are uploaded, without waiting for test results";
       export const Timeout = "Maximum time (in seconds) to wait for test results";

--- a/src/commands/test/lib/run-tests-command.ts
+++ b/src/commands/test/lib/run-tests-command.ts
@@ -6,6 +6,7 @@ import { TestCloudError } from "./test-cloud-error";
 import { StateChecker } from "./state-checker";
 import { MobileCenterClient } from "../../../util/apis";
 import { StreamingArrayOutput } from "../../../util/interaction";
+import { getUser } from "../../../util/profile";
 import { parseTestParameters } from "./parameters-parser";
 import { parseIncludedFiles } from "./included-files-parser";
 import { progressWithResult } from "./interaction";
@@ -149,14 +150,28 @@ export abstract class RunTestsCommand extends AppCommand {
     }
     catch (err) {
       let exitCode = err.exitCode || ErrorCodes.Exception;
-      
+      let message : string = null;
+      let profile = getUser();
+
+      let helpMessage = `Further error details: For help, please send the following information to us by going to https://mobile.azure.com/apps and starting a new conversation (using the icon in the bottom right corner of the screen)${os.EOL}
+        Environment: ${os.platform()}${os.EOL}
+        User Email: ${profile.email}${os.EOL}
+        User Name: ${profile.userName}${os.EOL}
+        User Id: ${profile.userId}${os.EOL}
+        App Upload Id: ${this.identifier}${os.EOL}
+        Timestamp: ${Date.now()}${os.EOL}
+        Operation: ${this.constructor.name}${os.EOL}`;
+
       if (err.message.indexOf("Not Found") !== -1)
       {
-        return failure(exitCode, `Requested resource not found - please check --app: ${this.identifier}`)
+        message = `Requested resource not found - please check --app: ${this.identifier}${os.EOL}${os.EOL}${helpMessage}`;
+      }
+      else
+      {
+        message = `${err.message}${os.EOL}${os.EOL}${helpMessage}`;
       }
 
-      
-      return failure(exitCode, err.message);
+      return failure(exitCode, message);
     }
   }
 

--- a/src/commands/test/lib/run-tests-command.ts
+++ b/src/commands/test/lib/run-tests-command.ts
@@ -149,6 +149,13 @@ export abstract class RunTestsCommand extends AppCommand {
     }
     catch (err) {
       let exitCode = err.exitCode || ErrorCodes.Exception;
+      
+      if (err.message.indexOf("Not Found") !== -1)
+      {
+        return failure(exitCode, `Requested resource not found - please check --app: ${this.identifier}`)
+      }
+
+      
       return failure(exitCode, err.message);
     }
   }

--- a/src/commands/test/lib/state-checker.ts
+++ b/src/commands/test/lib/state-checker.ts
@@ -34,7 +34,11 @@ export class StateChecker {
     }
     while (true) {
       let state = await out.progress("Checking status...", this.getTestRunState(this.client, this.testRunId));
-      this.streamingOutput.text((state) => `Current test status: ${state.message.join(os.EOL)}`, state);
+      if (state && state.message)
+      {
+        this.streamingOutput.text((state) => `Current test status: ${state.message.join(os.EOL)}`, state);
+      }
+      
       if (typeof state.exitCode === "number") {
         exitCode = state.exitCode;
         break;

--- a/src/commands/test/lib/test-cloud-uploader.ts
+++ b/src/commands/test/lib/test-cloud-uploader.ts
@@ -70,7 +70,7 @@ export class TestCloudUploader {
   }
 
   public async uploadAndStart(): Promise<StartedTestRun> {
-    let orgs = await getOrgsNamesList(this._client, debug);
+    let orgs = await getOrgsNamesList(this._client);
     let isOrg = false;
     for (let org of orgs) {
       if (org.name === this._userName)

--- a/src/commands/test/lib/uitest-preparer.ts
+++ b/src/commands/test/lib/uitest-preparer.ts
@@ -20,6 +20,12 @@ export class UITestPreparer {
   public keyPassword: string;
   public signInfo: string;
   public uiTestToolsDir: string;
+  public fixture: string[];
+  public includeCategory: string[];
+  public excludeCategory: string[];
+  public nunitXml: string;
+  public testChunk: boolean;
+  public fixtureChunk: boolean;
 
   constructor(artifactsDir: string, buildDir: string, appPath: string) {
     if (!artifactsDir) {
@@ -76,6 +82,30 @@ export class UITestPreparer {
 
     if (this.signInfo) {
       command += ` --sign-info "${this.signInfo}"`;
+    }
+
+    if (this.fixture) {
+      command += ` --fixture "${this.fixture}"`;
+    }
+
+    if (this.includeCategory) {
+      command += ` --include "${this.includeCategory}"`;
+    }
+
+    if (this.excludeCategory) {
+      command += ` --exclude "${this.excludeCategory}"`;
+    }
+
+    if (this.nunitXml) {
+      command += ` --nunit-xml "${this.nunitXml}"`;
+    }
+
+    if (this.testChunk) {
+      command += ` --test-chunk "${this.testChunk}"`;
+    }
+
+    if (this.fixtureChunk) {
+      command += ` --fixture-chunk "${this.fixtureChunk}"`;
     }
 
     return command;

--- a/src/commands/test/lib/uitest-preparer.ts
+++ b/src/commands/test/lib/uitest-preparer.ts
@@ -129,15 +129,16 @@ export class UITestPreparer {
     }
 
     let testCloudPath = path.join(toolsDir, "test-cloud.exe");
-    if (testCloudPath.includes(" ")) {
-      testCloudPath = `"${testCloudPath}"`;
-    }
 
     if (!await fileExists(testCloudPath))
     {
       throw new Error(`Cannot find test-cloud.exe, the exe was not found in the path specified by "--uitest-tools-dir".${os.EOL}` +
         `Please check that ${testCloudPath} points to a test-cloud.exe.${os.EOL}` +
         `Minimum required version is "${this.getMinimumVersionString()}".`);
+    }
+
+    if (testCloudPath.includes(" ")) {
+      testCloudPath = `"${testCloudPath}"`;
     }
 
     debug(`Using test cloud tools path: ${testCloudPath}`);

--- a/src/commands/test/lib/uitest-preparer.ts
+++ b/src/commands/test/lib/uitest-preparer.ts
@@ -1,5 +1,6 @@
 import { TestCloudError } from "./test-cloud-error";
 import { glob } from "../../../util/misc/promisfied-glob";
+import { directoryExists, fileExists } from "../../../util/misc/promisfied-fs";
 import * as _ from "lodash";
 import * as os from "os";
 import * as path from "path";
@@ -119,10 +120,28 @@ export class UITestPreparer {
 
   private async getTestCloudExecutablePath(): Promise<string> {
     let toolsDir = this.uiTestToolsDir || await this.findXamarinUITestNugetDir(this.buildDir);
+
+    if (!await directoryExists(toolsDir))
+    {
+      throw new Error(`Cannot find test-cloud.exe, the path specified by "--uitest-tools-dir" was not found.${os.EOL}` +
+        `Please check that "${toolsDir}" is a valid directory and contains test-cloud.exe.${os.EOL}` +
+        `Minimum required version is "${this.getMinimumVersionString()}".`);
+    }
+
     let testCloudPath = path.join(toolsDir, "test-cloud.exe");
     if (testCloudPath.includes(" ")) {
       testCloudPath = `"${testCloudPath}"`;
     }
+
+    if (!await fileExists(testCloudPath))
+    {
+      throw new Error(`Cannot find test-cloud.exe, the exe was not found in the path specified by "--uitest-tools-dir".${os.EOL}` +
+        `Please check that ${testCloudPath} points to a test-cloud.exe.${os.EOL}` +
+        `Minimum required version is "${this.getMinimumVersionString()}".`);
+    }
+
+    debug(`Using test cloud tools path: ${testCloudPath}`);
+
     return testCloudPath;
   }
 

--- a/src/commands/test/lib/uitest-preparer.ts
+++ b/src/commands/test/lib/uitest-preparer.ts
@@ -89,11 +89,15 @@ export class UITestPreparer {
     }
 
     if (this.includeCategory) {
-      command += ` --include "${this.includeCategory}"`;
+      this.includeCategory.forEach(category => {
+        command += ` --include "${category}"`;
+      });
     }
 
     if (this.excludeCategory) {
-      command += ` --exclude "${this.excludeCategory}"`;
+      this.excludeCategory.forEach(category => {
+        command += ` --exclude "${category}"`;
+      });
     }
 
     if (this.nunitXml) {

--- a/src/commands/test/lib/uitest-preparer.ts
+++ b/src/commands/test/lib/uitest-preparer.ts
@@ -85,7 +85,9 @@ export class UITestPreparer {
     }
 
     if (this.fixture) {
-      command += ` --fixture "${this.fixture}"`;
+      this.fixture.forEach(item => {
+        command += ` --fixture "${item}"`;
+      });
     }
 
     if (this.includeCategory) {

--- a/src/commands/test/run/uitest.ts
+++ b/src/commands/test/run/uitest.ts
@@ -49,6 +49,36 @@ export default class RunUITestsCommand extends RunTestsCommand {
   @hasArg
   uiTestToolsDir: string;
 
+  @help(Messages.TestCloud.Arguments.Fixture)
+  @longName("fixture")
+  @hasArg
+  fixture: string[];
+
+  @help(Messages.TestCloud.Arguments.IncludeCategory)
+  @longName("include-category")
+  @hasArg
+  includeCategory: string[];
+
+  @help(Messages.TestCloud.Arguments.ExcludeCategory)
+  @longName("exclude-category")
+  @hasArg
+  excludeCategory: string[];
+
+  @help(Messages.TestCloud.Arguments.NUnitXml)
+  @longName("nunit-xml")
+  @hasArg
+  nunitXml: string;
+
+  @help(Messages.TestCloud.Arguments.TestChunk)
+  @longName("test-chunk")
+  @hasArg
+  testChunk: boolean;
+
+  @help(Messages.TestCloud.Arguments.FixtureChunk)
+  @longName("fixture-chunk")
+  @hasArg
+  fixtureChunk: boolean;
+
   constructor(args: CommandArgs) {
     super(args);
   }
@@ -72,6 +102,12 @@ export default class RunUITestsCommand extends RunTestsCommand {
     preparer.keyAlias = this.keyAlias;
     preparer.keyPassword = this.keyPassword;
     preparer.uiTestToolsDir = this.uiTestToolsDir;
+    preparer.fixture = this.fixture;
+    preparer.includeCategory = this.includeCategory;
+    preparer.excludeCategory = this.excludeCategory;
+    preparer.nunitXml = this.nunitXml;
+    preparer.testChunk = this.testChunk;
+    preparer.fixtureChunk = this.fixtureChunk;
 
     return preparer.prepare();
   }

--- a/src/util/misc/ios-bundle-archiver.ts
+++ b/src/util/misc/ios-bundle-archiver.ts
@@ -14,13 +14,13 @@ export async function archiveAppBundle(appPath: string, ipaPath: string): Promis
     await pfs.mkdir(payloadPath);
     let tempAppPath = path.join(payloadPath, appPathBase);
 
-    let exitCode = await process.execAndWait(`ditto ${appPath} ${tempAppPath}`);
+    let exitCode = await process.execAndWait(`ditto "${appPath}" "${tempAppPath}"`);
     if (exitCode !== 0) {
       await pfs.rmDir(tempPath, true);
       throw new Error("Cannot archive app bundle.");
     }
     
-    exitCode = await process.execAndWait(`ditto -ck --sequesterRsrc ${tempPath} ${ipaPath}`);
+    exitCode = await process.execAndWait(`ditto -ck --sequesterRsrc "${tempPath}" "${ipaPath}"`);
     if (exitCode !== 0) {
       await pfs.rmDir(tempPath, true);
       throw new Error("Cannot archive app bundle.");

--- a/src/util/portal/portal-helper.ts
+++ b/src/util/portal/portal-helper.ts
@@ -2,8 +2,15 @@ export function getPortalBuildLink(portalBaseUrl: string, appOwner: string, appN
   return `${portalBaseUrl}/users/${appOwner}/apps/${appName}/build/branches/${branchName}/builds/${buildId}`;
 }
 
-export function getPortalTestLink(portalBaseUrl: string, appOwner: string, appName: string, seriesName: string, testRunId: string): string {
-  return `${portalBaseUrl}/users/${appOwner}/apps/${appName}/test/series/${seriesName}/runs/${testRunId}`;
+export function getPortalTestLink(portalBaseUrl: string, isOrg: boolean, appOwner: string, appName: string, seriesName: string, testRunId: string): string {
+  if (isOrg)
+  {
+    return `${portalBaseUrl}/orgs/${appOwner}/apps/${appName}/test/series/${seriesName}/runs/${testRunId}`;
+  }
+  else
+  {
+    return `${portalBaseUrl}/users/${appOwner}/apps/${appName}/test/series/${seriesName}/runs/${testRunId}`;
+  }
 }
 
 export function getPortalOrgLink(portalBaseUrl: string, orgName: string): string {

--- a/src/util/portal/portal-helper.ts
+++ b/src/util/portal/portal-helper.ts
@@ -2,6 +2,10 @@ export function getPortalBuildLink(portalBaseUrl: string, appOwner: string, appN
   return `${portalBaseUrl}/users/${appOwner}/apps/${appName}/build/branches/${branchName}/builds/${buildId}`;
 }
 
+export function getPortalTestLink(portalBaseUrl: string, appOwner: string, appName: string, seriesName: string, testRunId: string): string {
+  return `${portalBaseUrl}/users/${appOwner}/apps/${appName}/test/series/${seriesName}/runs/${testRunId}`;
+}
+
 export function getPortalOrgLink(portalBaseUrl: string, orgName: string): string {
   return `${portalBaseUrl}/orgs/${orgName}`;
 }

--- a/test/util/misc/ios-bundle-archiver-test.ts
+++ b/test/util/misc/ios-bundle-archiver-test.ts
@@ -1,0 +1,15 @@
+import { expect } from "chai";
+
+import * as process from "../../../src/util/misc/process-helper";
+
+describe('ios bundle archiver', function () {
+  
+  it("ditto works with spaces",  async function (): Promise<void> {
+    let error: (text: string) => void;
+    let output: (text: string) => void;
+    let exitCode = await process.execAndWait(`ditto "App With Space.app" "tmp"`, output, error);
+    
+    expect(exitCode).equals(1);
+    expect(exitCode).is.not.equal(3);
+  });
+});


### PR DESCRIPTION
# Motivation
There is a discrepancy between the parameters available when uploading tests via `test-cloud.exe` and those uploaded by `mobile-center-cli`.

This PR adresses that by introducing the ability to add those parameters to the uitest command.

Also including minor bug fixes with this PR that were bundled up in the assigned work.

# Requirements
This PR won't start functioning until UITest has implemented [this PR](https://github.com/xamarin/Xamarin.UITest/pull/1192) - after which I advise we update the minimum version on UITest within the mobile-center-cli.

This work is part of this [VSTS Ticket](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/22164).

And along with the UITest changes resolves [this github issue](https://github.com/Microsoft/mobile-center-cli/issues/237).

# Additional Bug Fixes
- [Test upload fails if .app name contains a space](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/22798)
- [Reports test run url to user on successful and unsuccessful test run](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/22133)
- [404 error when user/org/app name incorrect](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/22799)
- [Better error message for 500 error and other unhandled exceptions](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/22132)
- Adds better error messages when sending UITest tests if the specified uitest-tools-dir is not found or the test-cloud.exe is not there.