### PR TITLE
UITest: Fix incorrect logic on test-cloud.exe version check

### DIFF
--- a/src/commands/test/lib/uitest-preparer.ts
+++ b/src/commands/test/lib/uitest-preparer.ts
@@ -140,6 +140,11 @@ export class UITestPreparer {
     let minLength = Math.min(currentVersion.length, minimumVersion.length);
 
     for (let i = 0; i < minLength; i++) {
+      if (currentVersion[i] > minimumVersion[i])
+      {
+        return true;
+      }
+      
       if (currentVersion[i] < minimumVersion[i]) {
         return false;
       }


### PR DESCRIPTION
## Motivation
The upgrade to UITest 2.2.0 was triggering an issue present in the version check logic.

### Fix
If the major or minor version is greater than the minimum (rather than equal) then the current version is higher.