### PR TITLE
additional improvements for "codepush release" related commands

### DIFF
--- a/src/commands/codepush/lib/cordova-utils.ts
+++ b/src/commands/codepush/lib/cordova-utils.ts
@@ -3,10 +3,10 @@ import * as xml2js from "xml2js";
 import * as fs from "fs";
 import * as path from "path";
 
-export function getCordovaProjectAppVersion(): Promise<string> {
+export function getCordovaProjectAppVersion(projectRoot?: string): Promise<string> {
   return new Promise<string>((resolve, reject) => {
     try {
-      const projectRoot: string = process.cwd();
+      projectRoot = projectRoot || process.cwd();
       var configString: string = fs.readFileSync(path.join(projectRoot, "config.xml"), { encoding: "utf8" });
     } catch (error) {
       reject(new Error(`Unable to find or read "config.xml" in the CWD. The "release-cordova" command must be executed in a Cordova project folder.`));
@@ -23,14 +23,18 @@ export function getCordovaProjectAppVersion(): Promise<string> {
   });
 }
 
-export function isValidOS(platform: string): boolean {
-  switch (platform.toLowerCase()) {
+export function isValidOS(os: string): boolean {
+  switch (os.toLowerCase()) {
     case "android":
     case "ios":
       return true;
     default:
       return false;
   }
+}
+
+export function isValidPlatform(platform: string): boolean {
+  return platform.toLowerCase() == "cordova";
 }
 
 // Check whether the Cordova or PhoneGap CLIs are

--- a/src/commands/codepush/lib/hash-utils.ts
+++ b/src/commands/codepush/lib/hash-utils.ts
@@ -9,13 +9,14 @@ import * as pfs from "../../../util/misc/promisfied-fs";
 import * as path from "path";
 import * as stream from "stream";
 import * as _ from "lodash";
+import { isDirectory } from "./file-utils"
 
 // Do not throw an exception if either of these modules are missing, as they may not be needed by the
 // consumer of this file.
 const HASH_ALGORITHM = "sha256";
 
 export async function generatePackageHashFromDirectory(directoryPath: string, basePath: string): Promise<string> {
-  if (!(await pfs.stat(directoryPath)).isDirectory()) {
+  if (!isDirectory(directoryPath)) {
     throw new Error("Not a directory. Please either create a directory, or use hashFile().");
   }
 

--- a/src/commands/codepush/lib/react-native-utils.ts
+++ b/src/commands/codepush/lib/react-native-utils.ts
@@ -13,14 +13,15 @@ var childProcess = require("child_process");
 export var spawn = childProcess.spawn;
 
 export interface VersionSearchParams {
-  os: string;
+  os: string; // ios or android
   plistFile: string;
   plistFilePrefix: string;
   gradleFile: string;
 }
 
-export async function getReactNativeProjectAppVersion(versionSearchParams: VersionSearchParams): Promise<string> {
-  var projectPackageJson: any = require(path.join(process.cwd(), "package.json"));
+export function getReactNativeProjectAppVersion(versionSearchParams: VersionSearchParams, projectRoot?: string): Promise<string> {
+  projectRoot = projectRoot || process.cwd();
+  var projectPackageJson: any = require(path.join(projectRoot, "package.json"));
   var projectName: string = projectPackageJson.name;
 
   const fileExists = (file: string): boolean => {
@@ -88,7 +89,7 @@ export async function getReactNativeProjectAppVersion(versionSearchParams: Versi
       buildGradlePath = path.join(buildGradlePath, "build.gradle");
     }
 
-    if (await fileDoesNotExistOrIsDirectory(buildGradlePath)) {
+    if (fileDoesNotExistOrIsDirectory(buildGradlePath)) {
       throw new Error(`Unable to find gradle file "${buildGradlePath}".`);
     }
 
@@ -240,8 +241,8 @@ export function runReactNativeBundleCommand(bundleName: string, development: boo
   });
 }
 
-export function isValidOS(platform: string): boolean {
-  switch (platform.toLowerCase()) {
+export function isValidOS(os: string): boolean {
+  switch (os.toLowerCase()) {
     case "android":
     case "ios":
     case "windows":
@@ -249,6 +250,10 @@ export function isValidOS(platform: string): boolean {
     default:
       return false;
   }
+}
+
+export function isValidPlatform(platform: string): boolean {
+  return platform.toLowerCase() == "react-native";
 }
 
 export function isReactNativeProject(): boolean {

--- a/src/commands/codepush/lib/update-contents-tasks/sign.ts
+++ b/src/commands/codepush/lib/update-contents-tasks/sign.ts
@@ -3,7 +3,7 @@ import * as hashUtils from "../hash-utils";
 import * as jwt from "jsonwebtoken";
 import * as path from "path";
 import * as pfs from "../../../../util/misc/promisfied-fs";
-import { copyFileToTmpDir } from "../file-utils";
+import { copyFileToTmpDir, isDirectory } from "../file-utils";
 
 const CURRENT_CLAIM_VERSION: string = "1.0.0";
 const METADATA_FILE_NAME: string = ".codepushrelease"
@@ -28,8 +28,8 @@ export default async function sign(privateKeyPath: string, updateContentsPath: s
   }
 
   // If releasing a single file, copy the file to a temporary 'CodePush' directory in which to publish the release
-  if (!(await pfs.stat(updateContentsPath)).isDirectory()) {
-    updateContentsPath = await copyFileToTmpDir(updateContentsPath);
+  if (!isDirectory(updateContentsPath)) {
+    updateContentsPath = copyFileToTmpDir(updateContentsPath);
   }
 
   signatureFilePath = path.join(updateContentsPath, METADATA_FILE_NAME);

--- a/src/commands/codepush/lib/update-contents-tasks/zip.ts
+++ b/src/commands/codepush/lib/update-contents-tasks/zip.ts
@@ -2,7 +2,7 @@ import * as fs from "fs";
 import * as pfs from "../../../../util/misc/promisfied-fs";
 import * as path from "path";
 import * as JsZip from "jszip";
-import { generateRandomFilename, normalizePath } from "../file-utils";
+import { generateRandomFilename, normalizePath, isDirectory } from "../file-utils";
 
 interface ReleaseFile {
   sourceLocation: string; // The current location of the file on disk
@@ -13,7 +13,7 @@ export default function zip(updateContentsPath: string): Promise<string> {
   return new Promise<string>(async (resolve, reject) => {
     let releaseFiles: ReleaseFile[] = [];
 
-    if (!(await pfs.stat(updateContentsPath)).isDirectory()) {
+    if (!isDirectory(updateContentsPath)) {
       releaseFiles.push({
         sourceLocation: updateContentsPath,
         targetLocation: normalizePath(changeTmpFolderName(path.basename(updateContentsPath))) // Put the file in the root


### PR DESCRIPTION
1. add missed `hasArg`s
2. add `projectRoot?` prop for `getCordovaProjectAppVersion` and `getReactNativeProjectAppVersion` methods
3. make all method in `file-utils.ts` synchronous
4. add platform validation both for React and Cordova
5. other small fixes and improvements