### PR TITLE
Bump appcenter-file-upload-client-node from 1.2.2 to 1.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "@xmldom/xmldom": "0.7.5",
     "abort-controller": "3.0.0",
     "appcenter-file-upload-client": "0.0.24",
-    "appcenter-file-upload-client-node": "^1.2.2",
+    "appcenter-file-upload-client-node": "^1.2.3",
     "azure-storage": "2.10.4",
     "bplist": "0.0.4",
     "chalk": "4.1.2",


### PR DESCRIPTION
Update appcenter-file-upload-client-node to 1.2.3 version that has valid mime type for aab