### PR TITLE
[codepush] Add xcode-target-name param for retrieving the app version

### DIFF
--- a/src/commands/codepush/release-react.ts
+++ b/src/commands/codepush/release-react.ts
@@ -80,6 +80,12 @@ export default class CodePushReleaseReactCommand extends CodePushReleaseCommandB
   @defaultValue("Release")
   public buildConfigurationName: string;
 
+  @help("Name of target (PBXNativeTarget) which specifies the binary version you want to target this release at (iOS only)")
+  @shortName("xt")
+  @longName("xcode-target-name")
+  @hasArg
+  public xcodeTargetName: string;
+
   @help("Path to where the sourcemap for the resulting bundle should be written. If omitted, a sourcemap will not be generated")
   @shortName("s")
   @longName("sourcemap-output")
@@ -195,6 +201,7 @@ export default class CodePushReleaseReactCommand extends CodePushReleaseCommandB
         plistFilePrefix: this.plistFilePrefix,
         gradleFile: this.gradleFile,
         buildConfigurationName: this.buildConfigurationName,
+        xcodeTargetName: this.xcodeTargetName,
         projectFile: this.xcodeProjectFile,
       } as VersionSearchParams;
       this.targetBinaryVersion = await getReactNativeProjectAppVersion(versionSearchParams);


### PR DESCRIPTION
This PR adds a new property to the `codepush release-react` command called `xcode-target-name`. This property allows to set the Xcode target which should be used for retrieving the app version.

[AB#93449](https://msmobilecenter.visualstudio.com/Mobile-Center/_boards/board/t/TestCloud%20Mobile/Backlog%20Items/?workitem=93449)