### PR TITLE
Add condition for functional tests

### DIFF
--- a/.azurepipelines/appcenter-cli-1ES.yml
+++ b/.azurepipelines/appcenter-cli-1ES.yml
@@ -98,13 +98,13 @@ extends:
             pwsh: true
             workingDirectory: $(Build.SourcesDirectory)
           displayName: 'Run functional tests'
-          condition: and(succeeded(), ne(variables['SkipFunctionalTests'], 'true'))
+          condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), eq(variables['ForceRunFunctionalTests'], 'true')))
 
         - script: |
             [ -f './test/functional/testresult.xml' ]
           displayName: 'Verify that functional test result file exists'
-          workingDirectory: $(Build.SourcesDirectory)
-          condition: and(succeeded(), ne(variables['SkipFunctionalTests'], 'true'))
+          workingDirectory: $(Build.SourcesDirectory)          
+          condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), eq(variables['ForceRunFunctionalTests'], 'true')))
 
         - task: PublishTestResults@2
           inputs:
@@ -114,7 +114,7 @@ extends:
             failTaskOnFailedTests: true
             testRunTitle: 'Functional tests'
           displayName: 'Verify functional test result'
-          condition: and(succeeded(), ne(variables['SkipFunctionalTests'], 'true'))
+          condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), eq(variables['ForceRunFunctionalTests'], 'true')))
 
         - script: |
             npm pack


### PR DESCRIPTION
Added condition for running functional tests only on master branch or when we explicitly specify the env variable.

[Build with env variable 
](https://dev.azure.com/msmobilecenter/SDK/_build/results?buildId=1537635&view=results)[Build without env variable](https://dev.azure.com/msmobilecenter/SDK/_build/results?buildId=1537636&view=results)