### PR TITLE
Update path to react-native cli for RN versions 0.75 and above

### DIFF
--- a/src/commands/codepush/lib/react-native-utils.ts
+++ b/src/commands/codepush/lib/react-native-utils.ts
@@ -571,7 +571,12 @@ function getComposeSourceMapsPath(): string {
 
 function getCliPath(): string {
   if (process.platform === "win32") {
-    return path.join(getReactNativePackagePath(), "local-cli", "cli.js");
+    const react75orAbove = compare(coerce(getReactNativeVersion()).version, "0.75.0") !== -1;
+    if (react75orAbove) {
+      return path.join(getReactNativePackagePath(), "cli.js");
+    } else {
+      return path.join(getReactNativePackagePath(), "local-cli", "cli.js");
+    }
   }
 
   return path.join("node_modules", ".bin", "react-native");

--- a/src/commands/codepush/lib/react-native-utils.ts
+++ b/src/commands/codepush/lib/react-native-utils.ts
@@ -571,12 +571,11 @@ function getComposeSourceMapsPath(): string {
 
 function getCliPath(): string {
   if (process.platform === "win32") {
-    const react75orAbove = compare(coerce(getReactNativeVersion()).version, "0.75.0") !== -1;
-    if (react75orAbove) {
-      return path.join(getReactNativePackagePath(), "cli.js");
-    } else {
-      return path.join(getReactNativePackagePath(), "local-cli", "cli.js");
-    }
+    const reactNativeVersion = coerce(getReactNativeVersion()).version;
+    const isVersion75OrAbove = compare(reactNativeVersion, "0.75.0") >= 0;
+    return isVersion75OrAbove
+      ? path.join(getReactNativePackagePath(), "cli.js")
+      : path.join(getReactNativePackagePath(), "local-cli", "cli.js");
   }
 
   return path.join("node_modules", ".bin", "react-native");


### PR DESCRIPTION
### Description
Use new path to react-native CLI for React Native versions 0.75 and above for Windows OS.

[Build succeed.](https://dev.azure.com/msmobilecenter/SDK/_build/results?buildId=1551565&view=results)
### Links
[AB#109354](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/109354)
#2554
